### PR TITLE
cloudwatch_logs_subscription: add helper submodule

### DIFF
--- a/cloudwatch_logs_subscription/README.md
+++ b/cloudwatch_logs_subscription/README.md
@@ -1,0 +1,65 @@
+# Cloudwatch Logs to Observe Lambda
+
+Given a list of Cloudwatch Log Group names and an Observe lambda function, this
+module subscribes each Log Group to a lambda, creating necessary permissions
+along the way.
+
+Terraform 0.12 and newer. Submit pull-requests to `main` branch.
+
+## Usage
+
+```hcl
+resource "aws_cloudwatch_log_group" "group" {
+  name_prefix = random_pet.run.id
+}
+
+module "observe_lambda" {
+  source           = "github.com/observeinc/terraform-aws-lambda"
+  observe_customer = var.observe_customer
+  observe_token    = var.observe_token
+  observe_domain   = var.observe_domain
+  name             = random_pet.run.id
+}
+
+module "observe_lambda_cloudwatch_logs_subscription" {
+  source = "github.com/observeinc/terraform-aws-lambda//cloudwatch_logs_subscription"
+  lambda = module.observe_lambda.lambda_function
+  log_group_names = [
+    aws_cloudwatch_log_group.group.name
+  ]
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12.21 |
+| aws | >= 2.68 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | >= 2.68 |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| account | Account ID for log groups. If empty, account is assumed to be the same as lambda | `string` | `""` | no |
+| filter\_name | Filter name | `string` | `"observe-filter"` | no |
+| filter\_pattern | The filter pattern to use. For more information, see [Filter and Pattern Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html) | `string` | `""` | no |
+| lambda | Observe Lambda module | <pre>object({<br>    arn           = string<br>    function_name = string<br>  })</pre> | n/a | yes |
+| log\_group\_names | Cloudwatch Log Group names to subscribe to Observe Lambda | `list(string)` | n/a | yes |
+
+## Outputs
+
+No output.
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## License
+
+Apache 2 Licensed. See LICENSE for full details.

--- a/cloudwatch_logs_subscription/main.tf
+++ b/cloudwatch_logs_subscription/main.tf
@@ -1,0 +1,23 @@
+locals {
+  arn     = regex("arn:aws:lambda:(?P<region>[^:]+):(?P<account>[0-9]+)", var.lambda.arn)
+  region  = local.arn["region"]
+  account = var.account != "" ? var.account : local.arn["account"]
+}
+
+resource "aws_lambda_permission" "permission" {
+  count         = length(var.log_group_names)
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda.function_name
+  principal     = format("logs.%s.amazonaws.com", local.region)
+  source_arn    = format("arn:aws:logs:%s:%s:log-group:%s:*", local.region, local.account, var.log_group_names[count.index])
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "subscription_filter" {
+  count           = length(var.log_group_names)
+  name            = var.filter_name
+  log_group_name  = var.log_group_names[count.index]
+  filter_pattern  = var.filter_pattern
+  destination_arn = var.lambda.arn
+
+  depends_on = [aws_lambda_permission.permission]
+}

--- a/cloudwatch_logs_subscription/variables.tf
+++ b/cloudwatch_logs_subscription/variables.tf
@@ -1,0 +1,30 @@
+variable "lambda" {
+  description = "Observe Lambda module"
+  type = object({
+    arn           = string
+    function_name = string
+  })
+}
+
+variable "log_group_names" {
+  description = "Cloudwatch Log Group names to subscribe to Observe Lambda"
+  type        = list(string)
+}
+
+variable "filter_pattern" {
+  description = "The filter pattern to use. For more information, see [Filter and Pattern Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html)"
+  type        = string
+  default     = ""
+}
+
+variable "filter_name" {
+  description = "Filter name"
+  type        = string
+  default     = "observe-filter"
+}
+
+variable "account" {
+  description = "Account ID for log groups. If empty, account is assumed to be the same as lambda"
+  type        = string
+  default     = ""
+}

--- a/cloudwatch_logs_subscription/versions.tf
+++ b/cloudwatch_logs_subscription/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.12.21"
+
+  required_providers {
+    aws = ">= 2.68"
+  }
+}


### PR DESCRIPTION
Similar to our s3_bucket_subscription submodule, we now provide a
cloudwatch_logs_subscription submodule to simplify subscribing to our
lambda.