### PR TITLE
Add dead_letter_queue_desitnation to the lambda function

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This repository contains examples of how to solve for concrete usecases:
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
 | timeout | The amount of time that Lambda allows a function to run before stopping it.<br>The maximum allowed value is 900 seconds. | `number` | `60` | no |
 | vpc\_config | VPC Config | <pre>object({<br>    security_groups = list(object({<br>      id = string<br>    }))<br>    subnets = list(object({<br>      arn = string<br>      id  = string<br>    }))<br>  })</pre> | `null` | no |
+| dead\_letter_\queue\_destination|Send failed events/function executions to a dead letter queue arn sns or sqs| `string` | null | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,12 @@ resource "aws_lambda_function" "this" {
       OBSERVE_TOKEN = format("%s %s", var.observe_customer, var.observe_token)
     }, var.lambda_envvars)
   }
+  dynamic "dead_letter_config" {
+    for_each            = var.dead_letter_queue_destination == null ? [] : [1]
+    content {
+      target_arn        = var.dead_letter_queue_destination
+    }
+  }
 
   depends_on = [
     aws_iam_role_policy_attachment.lambda_logs,

--- a/variables.tf
+++ b/variables.tf
@@ -138,3 +138,8 @@ variable "vpc_config" {
   })
   default = null
 }
+variable "dead_letter_queue_destination" {
+  type        = string
+  default     = null
+  description = "Send failed events/function executions to a dead letter queue arn sns or sqs"
+}


### PR DESCRIPTION
Dead Letter Queue is required by certain security checks run by AWS security hub. This allows the function to get an existing sqs/sns queue as a dead Letter Queue. 