### PR TITLE
snapshot: adjust action prefixes

### DIFF
--- a/snapshot/variables.tf
+++ b/snapshot/variables.tf
@@ -36,7 +36,7 @@ variable "action" {
     "ecs:List*",
     "ecs:Describe*",
     "elasticache:Describe*",
-    "elbv2:Describe*",
+    "elasticloadbalancing:Describe*",
     "iam:Get*",
     "iam:List*",
     "lambda:List*",
@@ -44,7 +44,6 @@ variable "action" {
     "rds:Describe*",
     "redshift:Describe*",
     "route53:List*",
-    "route53:Describe*",
     "s3:List*",
   ]
 }


### PR DESCRIPTION
While the sdk declares an `elb` and `elbv2` service directory, the
underlying service name is `elasticloadbalancing`. This commit also
removes a superfluous prefix for route53.