### PR TITLE
lambda: add lambda_s3_custom_rules variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ No modules.
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the AWS Key Management Service (AWS KMS) key that's used to encrypt your function's environment variables.<br>If it's not provided, AWS Lambda uses a default service key. | `string` | `""` | no |
 | <a name="input_lambda_envvars"></a> [lambda\_envvars](#input\_lambda\_envvars) | Environment variables | `map(any)` | `{}` | no |
 | <a name="input_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#input\_lambda\_iam\_role\_arn) | ARN of IAM role to use for Lambda | `string` | `""` | no |
+| <a name="input_lambda_s3_custom_rules"></a> [lambda\_s3\_custom\_rules](#input\_lambda\_s3\_custom\_rules) | List of rules to apply when evaluating how to upload a given S3 object. | <pre>list(object({<br>    pattern = string<br>    headers = map(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_lambda_version"></a> [lambda\_version](#input\_lambda\_version) | Version of lambda binary to use | `string` | `"latest"` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | The amount of memory that your function has access to. Increasing the function's memory also increases its CPU allocation.<br>The default value is 128 MB. The value must be a multiple of 64 MB. | `number` | `128` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of Lambda resource | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,10 @@ resource "aws_lambda_function" "this" {
     variables = merge({
       OBSERVE_URL   = format("https://collect.%s/v1/observations", var.observe_domain)
       OBSERVE_TOKEN = format("%s %s", var.observe_customer, var.observe_token)
-    }, var.lambda_envvars)
+      }, length(var.lambda_s3_custom_rules) > 0 ? {
+      S3_CUSTOM_RULES = base64encode(jsonencode(var.lambda_s3_custom_rules))
+      } : {}
+    , var.lambda_envvars)
   }
 
   dynamic "dead_letter_config" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,6 +26,15 @@ variable "lambda_version" {
   default     = "latest"
 }
 
+variable "lambda_s3_custom_rules" {
+  description = "List of rules to evaluate how to upload a given S3 object to Obsere."
+  type = list(object({
+    pattern = string
+    headers = map(string)
+  }))
+  default = []
+}
+
 variable "s3_key_prefix" {
   description = "S3 key containing lambda binaries"
   type        = string


### PR DESCRIPTION
This commit adds an option to configure the `S3_CUSTOM_RULES`
environment variable used by the Observe lambda function.

This environment variable is a base64-encoded JSON array of "rules".
Each rule is composed of a regular expression and a map of HTTP headers.
The S3 URI of a created object will be sequentially compared against the
provided regular expressions. On the first match, we will apply the
associated HTTP headers to the outbound request towards Observe. If no
match is found, we fall back to inferred rules.