### PR TITLE
snapshot: extend default permissions

### DIFF
--- a/snapshot/variables.tf
+++ b/snapshot/variables.tf
@@ -39,6 +39,8 @@ variable "action" {
     "elasticloadbalancing:Describe*",
     "firehose:List*",
     "firehose:Describe*",
+    "kinesis:List*",
+    "kinesis:Describe*",
     "iam:Get*",
     "iam:List*",
     "lambda:List*",
@@ -47,6 +49,10 @@ variable "action" {
     "redshift:Describe*",
     "route53:List*",
     "s3:List*",
+    "sns:List*",
+    "sns:Get*",
+    "sqs:List*",
+    "sqs:Get*",
   ]
 }
 


### PR DESCRIPTION
Next lambda release will support Kinesis Data Streams, SNS Topics /
Subscriptions, and SQS Queues.