### PR TITLE
feat: allow multiple buckets in s3_bucket_subscription

### DIFF
--- a/examples/s3_bucket/README.md
+++ b/examples/s3_bucket/README.md
@@ -48,12 +48,14 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Type |
 |------|------|
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_object.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
 | [random_pet.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_bucket_count"></a> [bucket\_count](#input\_bucket\_count) | Number of buckets to create and subscribe. | `number` | `1` | no |
 | <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | Specifies object key name prefix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_filter_suffix"></a> [filter\_suffix](#input\_filter\_suffix) | Specifies object key name suffix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |

--- a/examples/s3_bucket/variables.tf
+++ b/examples/s3_bucket/variables.tf
@@ -14,6 +14,12 @@ variable "observe_domain" {
   default     = "observeinc.com"
 }
 
+variable "bucket_count" {
+  description = "Number of buckets to create and subscribe."
+  type        = number
+  default     = 1
+}
+
 variable "filter_prefix" {
   description = "Specifies object key name prefix on S3 bucket notifications."
   type        = string

--- a/s3_bucket_subscription/README.md
+++ b/s3_bucket_subscription/README.md
@@ -26,9 +26,9 @@ module "observe_lambda" {
 }
 
 module "observe_lambda_s3_subscription" {
-  source = "../../s3_bucket_subscription"
-  lambda = module.observe_lambda.lambda_function
-  bucket = aws_s3_bucket.bucket
+  source      = "../../s3_bucket_subscription"
+  lambda      = module.observe_lambda.lambda_function
+  bucket_arns = [aws_s3_bucket.bucket.arn]
 }
 ```
 
@@ -63,7 +63,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_bucket"></a> [bucket](#input\_bucket) | S3 bucket to subscribe to Observe Lambda | <pre>object({<br>    arn = string<br>    id  = string<br>  })</pre> | n/a | yes |
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | S3 bucket to subscribe to Observe Lambda.<br>Deprecated: use bucket\_arns instead. | <pre>object({<br>    arn = string<br>    id  = string<br>  })</pre> | `null` | no |
+| <a name="input_bucket_arns"></a> [bucket\_arns](#input\_bucket\_arns) | S3 bucket ARNs to subscribe to Observe Lambda | `list(string)` | `[]` | no |
 | <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | Specifies object key name prefix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_filter_suffix"></a> [filter\_suffix](#input\_filter\_suffix) | Specifies object key name suffix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `"observe-lambda-"` | no |

--- a/s3_bucket_subscription/variables.tf
+++ b/s3_bucket_subscription/variables.tf
@@ -7,11 +7,21 @@ variable "lambda" {
 }
 
 variable "bucket" {
-  description = "S3 bucket to subscribe to Observe Lambda"
+  description = <<-EOF
+    S3 bucket to subscribe to Observe Lambda.
+    Deprecated: use bucket_arns instead.
+  EOF
   type = object({
     arn = string
     id  = string
   })
+  default = null
+}
+
+variable "bucket_arns" {
+  description = "S3 bucket ARNs to subscribe to Observe Lambda"
+  type        = list(string)
+  default     = []
 }
 
 variable "filter_prefix" {


### PR DESCRIPTION
It is common to subscribe multiple buckets to the same lambda. Doing so
through multiple modules increases the number of policies required, so
we might as well just allow users to pass in a list of bucket ARNs
rather than confine them to a single bucket per invocation.