### PR TITLE
fix: pin aws provider to < 4.0.0

### DIFF
--- a/examples/cloudtrail/README.md
+++ b/examples/cloudtrail/README.md
@@ -29,7 +29,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 

--- a/examples/cloudtrail/versions.tf
+++ b/examples/cloudtrail/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws    = ">= 2.68"
+    aws    = ">= 2.68, <4.0.0"
     random = ">= 3.0.0"
     local  = ">= 2.0.0"
   }

--- a/examples/s3_access_logs/README.md
+++ b/examples/s3_access_logs/README.md
@@ -30,14 +30,14 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68, <4.0.0 |
 
 ## Modules
 

--- a/examples/s3_access_logs/versions.tf
+++ b/examples/s3_access_logs/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws    = ">= 2.68"
+    aws    = ">= 2.68, <4.0.0"
     random = ">= 3.0.0"
   }
 }

--- a/examples/s3_bucket/README.md
+++ b/examples/s3_bucket/README.md
@@ -26,14 +26,14 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68, <4.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules

--- a/examples/s3_bucket/versions.tf
+++ b/examples/s3_bucket/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws    = ">= 2.68"
+    aws    = ">= 2.68, <4.0.0"
     random = ">= 3.0.0"
   }
 }

--- a/examples/vpc_config/README.md
+++ b/examples/vpc_config/README.md
@@ -24,14 +24,14 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68, <4.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules

--- a/examples/vpc_config/versions.tf
+++ b/examples/vpc_config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.21"
 
   required_providers {
-    aws    = ">= 2.68"
+    aws    = ">= 2.68, <4.0.0"
     random = ">= 3.0.0"
   }
 }


### PR DESCRIPTION
It appears the latest major version bump in AWS provider is not
compatible with some of the modules we use for our examples. Pin
accordingly.