### PR TITLE
feat!: use per-customer collector endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository contains examples of how to solve for concrete usecases:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
 
 ## Providers

--- a/examples/s3_access_logs/README.md
+++ b/examples/s3_access_logs/README.md
@@ -29,7 +29,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 

--- a/examples/s3_access_logs/versions.tf
+++ b/examples/s3_access_logs/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.21"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 2.68, <4.0.0"

--- a/examples/s3_bucket/README.md
+++ b/examples/s3_bucket/README.md
@@ -25,7 +25,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 

--- a/examples/s3_bucket/versions.tf
+++ b/examples/s3_bucket/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.21"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 2.68, <4.0.0"

--- a/examples/vpc_config/README.md
+++ b/examples/vpc_config/README.md
@@ -23,7 +23,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 

--- a/examples/vpc_config/versions.tf
+++ b/examples/vpc_config/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.21"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 2.68, <4.0.0"

--- a/main.tf
+++ b/main.tf
@@ -32,8 +32,8 @@ resource "aws_lambda_function" "this" {
 
   environment {
     variables = merge({
-      OBSERVE_URL   = format("https://collect.%s/v1/http", var.observe_domain)
-      OBSERVE_TOKEN = format("%s %s", var.observe_customer, var.observe_token)
+      OBSERVE_URL   = format("https://%s.collect.%s/v1/http", var.observe_customer, var.observe_domain)
+      OBSERVE_TOKEN = var.observe_token
       }, length(var.lambda_s3_custom_rules) > 0 ? {
       S3_CUSTOM_RULES = base64encode(jsonencode(var.lambda_s3_custom_rules))
       } : {}

--- a/variables.tf
+++ b/variables.tf
@@ -11,6 +11,11 @@ variable "observe_customer" {
 variable "observe_token" {
   description = "Observe Token"
   type        = string
+
+  validation {
+    condition     = contains(split("", var.observe_token), ":")
+    error_message = "Token format does not follow {datastream_id}:{datastream_secret} format."
+  }
 }
 
 # Optional input variables

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.21"
+  required_version = ">= 0.13.0"
 
   required_providers {
     aws = ">= 2.68"


### PR DESCRIPTION
Migrate endpoint from `collect.observeinc.com` to
`{CUSTOMER_ID}.collect.observeinc.com`. In the process, datastream
tokens will be mandatory.