### PR TITLE
fix: support aws provider 4.0+

### DIFF
--- a/examples/cloudtrail/README.md
+++ b/examples/cloudtrail/README.md
@@ -29,7 +29,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 

--- a/examples/cloudtrail/versions.tf
+++ b/examples/cloudtrail/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.0"
 
   required_providers {
-    aws    = ">= 2.68, <4.0.0"
+    aws    = ">= 2.68"
     random = ">= 3.0.0"
     local  = ">= 2.0.0"
   }

--- a/examples/s3_access_logs/README.md
+++ b/examples/s3_access_logs/README.md
@@ -30,14 +30,14 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68, <4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
 
 ## Modules
 
@@ -52,6 +52,8 @@ Note that this will create AWS resources - once you are done, run `terraform des
 |------|------|
 | [aws_s3_bucket.access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket.monitored](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_acl.access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_acl.monitored](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 
 ## Inputs
 

--- a/examples/s3_access_logs/main.tf
+++ b/examples/s3_access_logs/main.tf
@@ -2,13 +2,16 @@ provider "aws" {}
 
 resource "aws_s3_bucket" "monitored" {
   bucket        = format("%s-access-logs", var.name)
-  acl           = "log-delivery-write"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "monitored" {
+  bucket = aws_s3_bucket.monitored.id
+  acl    = "log-delivery-write"
 }
 
 resource "aws_s3_bucket" "access_logs" {
   bucket = var.name
-  acl    = "private"
 
   logging {
     target_bucket = aws_s3_bucket.monitored.id
@@ -16,6 +19,11 @@ resource "aws_s3_bucket" "access_logs" {
   }
 
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "access_logs" {
+  bucket = aws_s3_bucket.access_logs.id
+  acl    = "private"
 }
 
 module "observe_lambda" {

--- a/examples/s3_access_logs/versions.tf
+++ b/examples/s3_access_logs/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 2.68, <4.0.0"
+    aws    = ">= 3.75"
     random = ">= 3.0.0"
   }
 }

--- a/examples/s3_bucket/README.md
+++ b/examples/s3_bucket/README.md
@@ -26,14 +26,14 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68, <4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
@@ -48,7 +48,8 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Type |
 |------|------|
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_object.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_acl.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_object.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [random_pet.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs

--- a/examples/s3_bucket/main.tf
+++ b/examples/s3_bucket/main.tf
@@ -5,8 +5,13 @@ resource "random_pet" "run" {
 resource "aws_s3_bucket" "bucket" {
   count         = var.bucket_count
   bucket        = format("%s-%d", random_pet.run.id, count.index)
-  acl           = "private"
   force_destroy = true
+}
+
+resource "aws_s3_bucket_acl" "bucket" {
+  count  = var.bucket_count
+  bucket = aws_s3_bucket.bucket[count.index].id
+  acl    = "private"
 }
 
 module "observe_lambda" {
@@ -25,7 +30,7 @@ module "observe_lambda_s3_subscription" {
   filter_suffix = var.filter_suffix
 }
 
-resource "aws_s3_bucket_object" "example" {
+resource "aws_s3_object" "example" {
   depends_on = [module.observe_lambda_s3_subscription]
   count      = length(aws_s3_bucket.bucket)
   key        = "example.json"

--- a/examples/s3_bucket/versions.tf
+++ b/examples/s3_bucket/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 2.68, <4.0.0"
+    aws    = ">= 3.75"
     random = ">= 3.0.0"
   }
 }

--- a/examples/vpc_config/README.md
+++ b/examples/vpc_config/README.md
@@ -24,14 +24,14 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68, <4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68, <4.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules

--- a/examples/vpc_config/versions.tf
+++ b/examples/vpc_config/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
-    aws    = ">= 2.68, <4.0.0"
+    aws    = ">= 3.75"
     random = ">= 3.0.0"
   }
 }


### PR DESCRIPTION
Remove pin on AWS provider version. We needed this to protect against backward incompatible changes to S3 schemas, but those have since been backported to 3.75 branch.