### PR TITLE
feat!: declare variables as nullable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This repository contains examples of how to solve for concrete usecases:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
 
 ## Providers

--- a/examples/cloudtrail/README.md
+++ b/examples/cloudtrail/README.md
@@ -28,7 +28,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
@@ -59,7 +59,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `"observeinc.com"` | no |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `null` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/cloudtrail/variables.tf
+++ b/examples/cloudtrail/variables.tf
@@ -11,5 +11,5 @@ variable "observe_token" {
 variable "observe_domain" {
   description = "Observe Domain"
   type        = string
-  default     = "observeinc.com"
+  default     = null
 }

--- a/examples/cloudtrail/versions.tf
+++ b/examples/cloudtrail/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws    = ">= 2.68"

--- a/examples/s3_access_logs/README.md
+++ b/examples/s3_access_logs/README.md
@@ -29,7 +29,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
@@ -61,7 +61,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Lambda name | `string` | n/a | yes |
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `"observeinc.com"` | no |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `null` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/s3_access_logs/variables.tf
+++ b/examples/s3_access_logs/variables.tf
@@ -11,7 +11,7 @@ variable "observe_token" {
 variable "observe_domain" {
   description = "Observe Domain"
   type        = string
-  default     = "observeinc.com"
+  default     = null
 }
 
 variable "name" {

--- a/examples/s3_access_logs/versions.tf
+++ b/examples/s3_access_logs/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws    = ">= 3.75"

--- a/examples/s3_bucket/README.md
+++ b/examples/s3_bucket/README.md
@@ -25,7 +25,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
@@ -57,10 +57,10 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_count"></a> [bucket\_count](#input\_bucket\_count) | Number of buckets to create and subscribe. | `number` | `1` | no |
-| <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | Specifies object key name prefix on S3 bucket notifications. | `string` | `""` | no |
-| <a name="input_filter_suffix"></a> [filter\_suffix](#input\_filter\_suffix) | Specifies object key name suffix on S3 bucket notifications. | `string` | `""` | no |
+| <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | Specifies object key name prefix on S3 bucket notifications. | `string` | `null` | no |
+| <a name="input_filter_suffix"></a> [filter\_suffix](#input\_filter\_suffix) | Specifies object key name suffix on S3 bucket notifications. | `string` | `null` | no |
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `"observeinc.com"` | no |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `null` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/s3_bucket/variables.tf
+++ b/examples/s3_bucket/variables.tf
@@ -11,23 +11,24 @@ variable "observe_token" {
 variable "observe_domain" {
   description = "Observe Domain"
   type        = string
-  default     = "observeinc.com"
+  default     = null
 }
 
 variable "bucket_count" {
   description = "Number of buckets to create and subscribe."
   type        = number
+  nullable    = false
   default     = 1
 }
 
 variable "filter_prefix" {
   description = "Specifies object key name prefix on S3 bucket notifications."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "filter_suffix" {
   description = "Specifies object key name suffix on S3 bucket notifications."
   type        = string
-  default     = ""
+  default     = null
 }

--- a/examples/s3_bucket/versions.tf
+++ b/examples/s3_bucket/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws    = ">= 3.75"

--- a/examples/vpc_config/README.md
+++ b/examples/vpc_config/README.md
@@ -23,7 +23,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 

--- a/examples/vpc_config/versions.tf
+++ b/examples/vpc_config/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws    = ">= 3.75"

--- a/modules/cloudwatch_logs_subscription/README.md
+++ b/modules/cloudwatch_logs_subscription/README.md
@@ -42,7 +42,7 @@ module "observe_lambda_cloudwatch_logs_subscription" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
 
 ## Providers

--- a/modules/cloudwatch_logs_subscription/variables.tf
+++ b/modules/cloudwatch_logs_subscription/variables.tf
@@ -17,29 +17,34 @@ variable "allow_all_log_groups" {
     This works around policy limits when subscribing many log groups to a single lambda."
   EOF
   type        = bool
+  nullable    = false
   default     = false
 }
 
 variable "filter_pattern" {
   description = "The filter pattern to use. For more information, see [Filter and Pattern Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html)"
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "filter_name" {
   description = "Filter name"
   type        = string
+  nullable    = false
   default     = "observe-filter"
 }
 
 variable "account" {
   description = "Account ID for log groups. If empty, account is assumed to be the same as lambda"
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "statement_id_prefix" {
   description = "Prefix used for Lambda permission statement ID"
   type        = string
+  nullable    = false
   default     = "observe-lambda"
 }

--- a/modules/cloudwatch_logs_subscription/versions.tf
+++ b/modules/cloudwatch_logs_subscription/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.21"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = ">= 2.68"

--- a/modules/s3_bucket_subscription/README.md
+++ b/modules/s3_bucket_subscription/README.md
@@ -37,7 +37,7 @@ module "observe_lambda_s3_subscription" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
 
 ## Providers

--- a/modules/s3_bucket_subscription/variables.tf
+++ b/modules/s3_bucket_subscription/variables.tf
@@ -15,35 +15,41 @@ variable "bucket" {
     arn = string
     id  = string
   })
-  default = null
+  nullable = true
+  default  = null
 }
 
 variable "bucket_arns" {
   description = "S3 bucket ARNs to subscribe to Observe Lambda"
   type        = list(string)
+  nullable    = false
   default     = []
 }
 
 variable "filter_prefix" {
   description = "Specifies object key name prefix on S3 bucket notifications."
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "filter_suffix" {
   description = "Specifies object key name suffix on S3 bucket notifications."
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "iam_name_prefix" {
   description = "Prefix used for all created IAM roles and policies"
   type        = string
+  nullable    = false
   default     = "observe-lambda-"
 }
 
 variable "statement_id_prefix" {
   description = "Prefix used for Lambda permission statement ID"
   type        = string
+  nullable    = false
   default     = ""
 }

--- a/modules/s3_bucket_subscription/versions.tf
+++ b/modules/s3_bucket_subscription/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.21"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = ">= 2.68"

--- a/modules/snapshot/README.md
+++ b/modules/snapshot/README.md
@@ -98,7 +98,7 @@ module "observe_lambda_snapshot" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.21 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
 
 ## Providers

--- a/modules/snapshot/variables.tf
+++ b/modules/snapshot/variables.tf
@@ -11,18 +11,21 @@ variable "lambda" {
 variable "iam_name_prefix" {
   description = "Prefix used for all created IAM roles and policies"
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "statement_id_prefix" {
   description = "Prefix used for Lambda permission statement ID"
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "eventbridge_name_prefix" {
   description = "Prefix used for eventbridge rule"
   type        = string
+  nullable    = false
   default     = "observe-lambda-snapshot-"
 }
 
@@ -35,6 +38,7 @@ variable "action" {
     this list, or ignore a subset of actions, use \"include\" and \"exclude\".
   EOF
   type        = list(string)
+  nullable    = false
   default = [
     "apigateway:Get*",
     "autoscaling:Describe*",
@@ -85,18 +89,21 @@ variable "action" {
 variable "include" {
   description = "List of actions to include in snapshot request."
   type        = list(string)
+  nullable    = false
   default     = []
 }
 
 variable "exclude" {
   description = "List of actions to exclude from being executed on snapshot request."
   type        = list(string)
+  nullable    = false
   default     = []
 }
 
 variable "resources" {
   description = "List of resources to scope policy to."
   type        = list(string)
+  nullable    = false
   default     = ["*"]
 }
 
@@ -106,17 +113,20 @@ variable "overrides" {
     action = string
     config = map(any)
   }))
-  default = []
+  nullable = false
+  default  = []
 }
 
 variable "eventbridge_schedule_event_bus_name" {
   description = "Event Bus for EventBridge scheduled events"
   type        = string
+  nullable    = false
   default     = "default"
 }
 
 variable "eventbridge_schedule_expression" {
   description = "Rate at which snapshot is triggered. Must be valid EventBridge expression"
   type        = string
+  nullable    = false
   default     = "rate(3 hours)"
 }

--- a/modules/snapshot/versions.tf
+++ b/modules/snapshot/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.21"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = ">= 2.68"

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,7 @@ variable "observe_token" {
 variable "observe_domain" {
   description = "Observe domain"
   type        = string
+  nullable    = false
   default     = "observeinc.com"
 }
 
@@ -29,6 +30,7 @@ variable "lambda_version" {
   description = "Version of lambda binary to use"
   type        = string
   default     = "latest"
+  nullable    = false
 }
 
 variable "lambda_s3_custom_rules" {
@@ -37,42 +39,49 @@ variable "lambda_s3_custom_rules" {
     pattern = string
     headers = map(string)
   }))
-  default = []
+  nullable = false
+  default  = []
 }
 
 variable "s3_key_prefix" {
   description = "S3 key containing lambda binaries"
   type        = string
+  nullable    = false
   default     = "lambda/observer"
 }
 
 variable "s3_regional_buckets" {
   description = "Map of AWS regions to lambda hosting S3 buckets"
   type        = map(any)
+  nullable    = false
   default     = {}
 }
 
 variable "s3_bucket" {
   description = "S3 Bucket hosting lambda binary. If provided, overrides regional bucket map"
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "s3_key" {
   description = "S3 object key for lambda binary. If provided, overrides s3_key_prefix"
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "s3_object_version" {
   description = "S3 object version for lambda binary"
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "description" {
   description = "Lambda description"
   type        = string
+  nullable    = false
   default     = "Lambda function to forward events towards Observe"
 }
 
@@ -82,6 +91,7 @@ variable "memory_size" {
     The default value is 128 MB. The value must be a multiple of 64 MB.
   EOF
   type        = number
+  nullable    = false
   default     = 128
 }
 
@@ -91,24 +101,28 @@ variable "timeout" {
     The maximum allowed value is 900 seconds.
   EOF
   type        = number
+  nullable    = false
   default     = 60
 }
 
 variable "reserved_concurrent_executions" {
   description = "The number of simultaneous executions to reserve for the function."
   type        = number
+  nullable    = false
   default     = 100
 }
 
 variable "tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)
+  nullable    = false
   default     = {}
 }
 
 variable "iam_name_prefix" {
   description = "Prefix used for all created IAM roles and policies"
   type        = string
+  nullable    = false
   default     = "observe-lambda-"
 }
 
@@ -118,24 +132,28 @@ variable "kms_key_arn" {
     If it's not provided, AWS Lambda uses a default service key.
   EOF
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "lambda_iam_role_arn" {
   description = "ARN of IAM role to use for Lambda"
   type        = string
+  nullable    = false
   default     = ""
 }
 
 variable "retention_in_days" {
   description = "Retention in days of cloudwatch log group"
   type        = number
+  nullable    = false
   default     = 14
 }
 
 variable "lambda_envvars" {
   description = "Environment variables"
   type        = map(any)
+  nullable    = false
   default     = {}
 }
 
@@ -150,11 +168,13 @@ variable "vpc_config" {
       id  = string
     }))
   })
-  default = null
+  nullable = true
+  default  = null
 }
 
 variable "dead_letter_queue_destination" {
-  type        = string
-  default     = null
   description = "Send failed events/function executions to a dead letter queue arn sns or sqs"
+  type        = string
+  nullable    = true
+  default     = null
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = ">= 2.68"


### PR DESCRIPTION
This commit introduces the `nullable` argument to variable blocks. As a result of this change, the minimum provider version is bumped to 1.1.0.

The `nullable` argument allows callers of this module to override variables while still being able to fall back to our defaults, e.g.

```
    variable "memory_size" {
      type    = number
      default = null
    }

    module "observe_lambda" {
      source  = "observeinc/lambda/aws"
      ...
      memory_size      = var.memory_size
    }
```

Previously, passing `null` to `memory_size` in our module would error out, since the variable was expected to be a string. Now, passing `null` will cause terraform to fall back to the underlying default.
