### PR TITLE
fix(s3_bucket_subscription)!: remove `bucket` variable

### DIFF
--- a/examples/cloudtrail/main.tf
+++ b/examples/cloudtrail/main.tf
@@ -31,12 +31,9 @@ module "observe_lambda" {
 }
 
 module "observe_lambda_s3_subscription" {
-  source = "../..//modules/s3_bucket_subscription"
-  lambda = module.observe_lambda.lambda_function
-  bucket = {
-    arn = module.cloudtrail_s3_bucket.bucket_arn
-    id  = module.cloudtrail_s3_bucket.bucket_id
-  }
+  source      = "../..//modules/s3_bucket_subscription"
+  lambda      = module.observe_lambda.lambda_function
+  bucket_arns = [module.cloudtrail_s3_bucket.bucket_arn, ]
 
   # ensure we delete our policy attachments before tearing down policy
   # attachments in the following module, otherwise we hit "conflicting

--- a/examples/s3_access_logs/main.tf
+++ b/examples/s3_access_logs/main.tf
@@ -35,7 +35,7 @@ module "observe_lambda" {
 }
 
 module "observe_lambda_s3_subscription" {
-  source = "../..//modules/s3_bucket_subscription"
-  lambda = module.observe_lambda.lambda_function
-  bucket = aws_s3_bucket.access_logs
+  source      = "../..//modules/s3_bucket_subscription"
+  lambda      = module.observe_lambda.lambda_function
+  bucket_arns = [aws_s3_bucket.access_logs.arn, ]
 }

--- a/modules/s3_bucket_subscription/README.md
+++ b/modules/s3_bucket_subscription/README.md
@@ -63,7 +63,6 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_bucket"></a> [bucket](#input\_bucket) | S3 bucket to subscribe to Observe Lambda.<br>Deprecated: use bucket\_arns instead. | <pre>object({<br>    arn = string<br>    id  = string<br>  })</pre> | `null` | no |
 | <a name="input_bucket_arns"></a> [bucket\_arns](#input\_bucket\_arns) | S3 bucket ARNs to subscribe to Observe Lambda | `list(string)` | `[]` | no |
 | <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | Specifies object key name prefix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_filter_suffix"></a> [filter\_suffix](#input\_filter\_suffix) | Specifies object key name suffix on S3 bucket notifications. | `string` | `""` | no |

--- a/modules/s3_bucket_subscription/main.tf
+++ b/modules/s3_bucket_subscription/main.tf
@@ -1,8 +1,8 @@
 locals {
   role_name           = regex(".*role/(?P<role_name>.*)$", var.lambda.role)["role_name"]
   statement_id_prefix = var.statement_id_prefix != "" ? var.statement_id_prefix : var.iam_name_prefix
-  bucket_arns         = var.bucket == null ? var.bucket_arns : [var.bucket.arn]
-  bucket_count        = length(local.bucket_arns)
+  bucket_arns         = var.bucket_arns
+  bucket_count        = length(var.bucket_arns)
 }
 
 resource "aws_lambda_permission" "allow_bucket" {

--- a/modules/s3_bucket_subscription/variables.tf
+++ b/modules/s3_bucket_subscription/variables.tf
@@ -6,19 +6,6 @@ variable "lambda" {
   })
 }
 
-variable "bucket" {
-  description = <<-EOF
-    S3 bucket to subscribe to Observe Lambda.
-    Deprecated: use bucket_arns instead.
-  EOF
-  type = object({
-    arn = string
-    id  = string
-  })
-  nullable = true
-  default  = null
-}
-
 variable "bucket_arns" {
   description = "S3 bucket ARNs to subscribe to Observe Lambda"
   type        = list(string)


### PR DESCRIPTION
This commit removes the deprecated `bucket` variable. Users should migrate to using `bucket_arns` instead.