### PR TITLE
feat(s3_bucket_subscription)!: convert `bucket_arns` to set

### DIFF
--- a/modules/s3_bucket_subscription/README.md
+++ b/modules/s3_bucket_subscription/README.md
@@ -63,7 +63,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_bucket_arns"></a> [bucket\_arns](#input\_bucket\_arns) | S3 bucket ARNs to subscribe to Observe Lambda | `list(string)` | `[]` | no |
+| <a name="input_bucket_arns"></a> [bucket\_arns](#input\_bucket\_arns) | S3 bucket ARNs to subscribe to Observe Lambda | `set(string)` | `[]` | no |
 | <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | Specifies object key name prefix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_filter_suffix"></a> [filter\_suffix](#input\_filter\_suffix) | Specifies object key name suffix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `"observe-lambda-"` | no |

--- a/modules/s3_bucket_subscription/variables.tf
+++ b/modules/s3_bucket_subscription/variables.tf
@@ -8,7 +8,7 @@ variable "lambda" {
 
 variable "bucket_arns" {
   description = "S3 bucket ARNs to subscribe to Observe Lambda"
-  type        = list(string)
+  type        = set(string)
   nullable    = false
   default     = []
 }


### PR DESCRIPTION
This commit changes the type of `bucket_arns` from `list(string)` to `set(string)`. This change makes the module robust against reordering, and naturally handles the case where duplicates are provided.

BREAKING CHANGE: migrating from previous versions may result in a race condition where terraform attempts to create a new `aws_s3_bucket_notification` prior to destroying the previous one. Re-running apply should successfully work around this issue.