### PR TITLE
feat(s3_bucket_subscription)!: revert `bucket_arns` to count

### DIFF
--- a/modules/s3_bucket_subscription/README.md
+++ b/modules/s3_bucket_subscription/README.md
@@ -64,7 +64,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_bucket_arns"></a> [bucket\_arns](#input\_bucket\_arns) | S3 bucket ARNs to subscribe to Observe Lambda | `set(string)` | `[]` | no |
+| <a name="input_bucket_arns"></a> [bucket\_arns](#input\_bucket\_arns) | S3 bucket ARNs to subscribe to Observe Lambda | `list(string)` | `[]` | no |
 | <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | Specifies object key name prefix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_filter_suffix"></a> [filter\_suffix](#input\_filter\_suffix) | Specifies object key name suffix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `"observe-lambda-"` | no |

--- a/modules/s3_bucket_subscription/main.tf
+++ b/modules/s3_bucket_subscription/main.tf
@@ -4,22 +4,22 @@ locals {
 }
 
 data "aws_arn" "bucket" {
-  for_each = var.bucket_arns
-  arn      = each.key
+  count = length(var.bucket_arns)
+  arn   = var.bucket_arns[count.index]
 }
 
 resource "aws_lambda_permission" "allow_bucket" {
-  for_each            = var.bucket_arns
+  count               = length(var.bucket_arns)
   statement_id_prefix = local.statement_id_prefix
   action              = "lambda:InvokeFunction"
   function_name       = var.lambda.arn
   principal           = "s3.amazonaws.com"
-  source_arn          = each.key
+  source_arn          = var.bucket_arns[count.index]
 }
 
 resource "aws_s3_bucket_notification" "notification" {
-  for_each = var.bucket_arns
-  bucket   = data.aws_arn.bucket[each.key].resource
+  count  = length(data.aws_arn.bucket)
+  bucket = data.aws_arn.bucket[count.index].resource
   lambda_function {
     lambda_function_arn = var.lambda.arn
     events              = ["s3:ObjectCreated:*"]

--- a/modules/s3_bucket_subscription/variables.tf
+++ b/modules/s3_bucket_subscription/variables.tf
@@ -8,7 +8,7 @@ variable "lambda" {
 
 variable "bucket_arns" {
   description = "S3 bucket ARNs to subscribe to Observe Lambda"
-  type        = set(string)
+  type        = list(string)
   nullable    = false
   default     = []
 }


### PR DESCRIPTION
This reverts commit a13b8fd75c8f1e882da0d2869a39acd06930a9e0.

A drawback of using `set` and `for_each` is that the keys must be known at apply-time in order to be used to address resource instances. This is a fundamental limitation:
https://developer.hashicorp.com/terraform/language/meta-arguments/for_each#limitations-on-values-used-in-for_each

In the context of this module, users pass in a collection a buckets. There is no obvious key that can be used to satisfy the current constraint for `for_each`. In the absence of an obvious candidate, users can enumerate a list and provide an index, at which point we're back to the same limitations that `count` has. At that point, it is better to revert and maintain backward compatibility with 1.x, and defer changes that attempt to retain stable resource identifiers for future major revisions.

This snafu should have been caught during testing - unfortunately we do not run plan or apply as part of our current CI jobs, and manual testing focused on the upgrade path rather than clean apply.