### PR TITLE
docs: cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,11 @@
 
 Terraform module which sets up a Lambda to forward event data towards Observe.
 
-## Terraform versions
-
-Terraform 0.12 and newer. Submit pull-requests to `main` branch.
-
 ## Usage
 
 ```hcl
 module "observe_lambda" {
-  source = "github.com/observeinc/terraform-aws-lambda"
+  source = "observeinc/lambda/aws"
 
   name                = "observe-lambda"
   observe_customer    = "<id>"

--- a/modules/cloudwatch_logs_subscription/README.md
+++ b/modules/cloudwatch_logs_subscription/README.md
@@ -11,8 +11,6 @@ overrun AWS limits. In such cases, you can set the `allow_all_log_groups`
 variable to use a single, more permissive policy, rather than a large set of
 restrictive ones.
 
-Terraform 0.12 and newer. Submit pull-requests to `main` branch.
-
 ## Usage
 
 ```hcl
@@ -21,7 +19,7 @@ resource "aws_cloudwatch_log_group" "group" {
 }
 
 module "observe_lambda" {
-  source           = "github.com/observeinc/terraform-aws-lambda"
+  source           = "observeinc/lambda/aws"
   observe_customer = var.observe_customer
   observe_token    = var.observe_token
   observe_domain   = var.observe_domain
@@ -29,7 +27,7 @@ module "observe_lambda" {
 }
 
 module "observe_lambda_cloudwatch_logs_subscription" {
-  source = "github.com/observeinc/terraform-aws-lambda//cloudwatch_logs_subscription"
+  source = "observeinc/lambda/aws//cloudwatch_logs_subscription"
   lambda = module.observe_lambda.lambda_function
   log_group_names = [
     aws_cloudwatch_log_group.group.name

--- a/modules/s3_bucket_subscription/README.md
+++ b/modules/s3_bucket_subscription/README.md
@@ -4,10 +4,6 @@ Given an S3 bucket and an Observe lambda function, this module notifies the
 lambda on object creation events, and grants the necessary permissions for the
 lambda function to retrieve the newly created object.
 
-## Terraform versions
-
-Terraform 0.12 and newer. Submit pull-requests to `main` branch.
-
 ## Usage
 
 ```hcl
@@ -18,7 +14,7 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 module "observe_lambda" {
-  source           = "github.com/observeinc/terraform-aws-lambda"
+  source           = "observeinc/lambda/aws"
   observe_customer = var.observe_customer
   observe_token    = var.observe_token
   observe_domain   = var.observe_domain
@@ -26,7 +22,7 @@ module "observe_lambda" {
 }
 
 module "observe_lambda_s3_subscription" {
-  source      = "github.com/observeinc/terraform-aws-lambda//modules/s3_bucket_subscription"
+  source      = "observeinc/lambda/aws//modules/s3_bucket_subscription"
   lambda      = module.observe_lambda.lambda_function
   bucket_arns = [aws_s3_bucket.bucket.arn]
 }

--- a/modules/snapshot/README.md
+++ b/modules/snapshot/README.md
@@ -5,10 +5,6 @@ module sets up an event rule in EventBridge which triggers the Observe Lambda
 periodically. Additionally, the module will add a policy to the existing lambda
 to ensure that all requested endpoints are accessible.
 
-## Terraform versions
-
-Terraform 0.12 and newer. Submit pull-requests to `main` branch.
-
 ## Usage
 
 ```hcl


### PR DESCRIPTION
The terraform provider requirements are already compiled by terraform-docs.

Module sources should point towards module registry.

Suggestions on how to contribute should be instead provided via CONTRIBUTING file.