### PR TITLE
fix(s3_bucket_subscription): avoid race on subscription

### DIFF
--- a/modules/s3_bucket_subscription/main.tf
+++ b/modules/s3_bucket_subscription/main.tf
@@ -9,19 +9,19 @@ data "aws_arn" "bucket" {
 }
 
 resource "aws_lambda_permission" "allow_bucket" {
-  count               = length(var.bucket_arns)
+  count               = length(data.aws_arn.bucket)
   statement_id_prefix = local.statement_id_prefix
   action              = "lambda:InvokeFunction"
   function_name       = var.lambda.arn
   principal           = "s3.amazonaws.com"
-  source_arn          = var.bucket_arns[count.index]
+  source_arn          = data.aws_arn.bucket[count.index].arn
 }
 
 resource "aws_s3_bucket_notification" "notification" {
-  count  = length(data.aws_arn.bucket)
+  count  = length(aws_lambda_permission.allow_bucket)
   bucket = data.aws_arn.bucket[count.index].resource
   lambda_function {
-    lambda_function_arn = var.lambda.arn
+    lambda_function_arn = aws_lambda_permission.allow_bucket[count.index].function_name
     events              = ["s3:ObjectCreated:*"]
     filter_prefix       = var.filter_prefix
     filter_suffix       = var.filter_suffix


### PR DESCRIPTION
Currently on applying this module, users may hit the following error:

```
│ Error: putting S3 Bucket Notification Configuration: InvalidArgument: Unable to validate the following destination configurations
│       status code: 400, request id: 9DXT97CA77A3MTPX, host id: 9R+2v/kbrAp57YCPbITdTv4XUzLSq7rlzANk3rIQjRSNsKJxaA4wsPIgNNr8UmaAKNOaEPPkS0wO/A1mEOS4xw==
```

This appears to be due to a race between applying
`aws_lambda_permission` and `aws_s3_bucket_notification`. This commit ensures the S3 bucket has permission to invoke the lambda prior to assigning the lambda as a target for bucket notifications.
