### PR TITLE
chore(workflows): allow dry-run release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,17 @@
 name: Release and push
 on:
   workflow_dispatch:
+    inputs:
+      push:
+        required: false
+        type: boolean
+        description: Pushes the release commit and tag. Disable this to perform a dry-run. 
+        default: true
 
 jobs:
   bump:
-    uses: observeinc/.github/.github/workflows/terraform_release.yaml@main
+    uses: observeinc/.github/.github/workflows/terraform_release.yaml@release-push
     secrets: inherit
     with:
       release-count: 1
+      push: ${{ inputs.push }}


### PR DESCRIPTION
## What does this PR do?

Allows releasers to trigger a dry-run and not actually push any of the release content. 

## Motivation

We are getting unexpected output when generating the release content/version and need to be able to debug this without creating live releases every time.

https://github.com/observeinc/terraform-aws-lambda/actions/runs/4326680129/jobs/7554389442#step:3:89

## Limitations

This can't be readily tested until it lands in `main`, because Actions won't process the workflow:

https://stackoverflow.com/questions/63362126/github-actions-how-to-run-a-workflow-created-on-a-non-master-branch-from-the-wo

You can dispatch on non-main branches, but the workflow content will be from the main branch:

```sh
gh workflow run 34990775 --ref test-push-false --field push=false
```

```
could not create workflow dispatch event: HTTP 422: Unexpected inputs provided: ["push"] (https://api.github.com/repos/observeinc/terraform-aws-lambda/actions/workflows/34990775/dispatches)
```

I've left behind `@release-push` in the workflow reference but this needs to be reverted as soon as we've verified that the `push` inputs works and can merge https://github.com/observeinc/.github/pull/62.