### PR TITLE
chore(workflow): revert release workflow to `@main`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   bump:
-    uses: observeinc/.github/.github/workflows/terraform_release.yaml@release-push
+    uses: observeinc/.github/.github/workflows/terraform_release.yaml@main
     secrets: inherit
     with:
       release-count: 1


### PR DESCRIPTION
Reverts a temporary ref used to validate #55 without merging the upstream workflow