### PR TITLE
refactor(cloudwatch_logs_subscription): replace regex with data.aws_arn

### DIFF
--- a/modules/cloudwatch_logs_subscription/README.md
+++ b/modules/cloudwatch_logs_subscription/README.md
@@ -60,6 +60,7 @@ No modules.
 | [aws_cloudwatch_log_subscription_filter.subscription_filter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_subscription_filter) | resource |
 | [aws_lambda_permission.permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_lambda_permission.permission_allow_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_arn.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 
 ## Inputs
 

--- a/modules/cloudwatch_logs_subscription/main.tf
+++ b/modules/cloudwatch_logs_subscription/main.tf
@@ -1,7 +1,10 @@
 locals {
-  arn     = regex("arn:aws:lambda:(?P<region>[^:]+):(?P<account>[0-9]+)", var.lambda.arn)
-  region  = local.arn["region"]
-  account = var.account != "" ? var.account : local.arn["account"]
+  account = coalesce(var.account, data.aws_arn.this.account)
+  region  = data.aws_arn.this.region
+}
+
+data "aws_arn" "this" {
+  arn = var.lambda.arn
 }
 
 resource "aws_lambda_permission" "permission" {


### PR DESCRIPTION
This commit replaces the use of regexing ARNs with a data source construct.