### PR TITLE
feat: add s3_bucket module

### DIFF
--- a/examples/s3_bucket/README.md
+++ b/examples/s3_bucket/README.md
@@ -26,14 +26,14 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
@@ -42,13 +42,12 @@ Note that this will create AWS resources - once you are done, run `terraform des
 |------|--------|---------|
 | <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | ../.. | n/a |
 | <a name="module_observe_lambda_s3_subscription"></a> [observe\_lambda\_s3\_subscription](#module\_observe\_lambda\_s3\_subscription) | ../..//modules/s3_bucket_subscription | n/a |
+| <a name="module_observe_s3_bucket"></a> [observe\_s3\_bucket](#module\_observe\_s3\_bucket) | ../..//modules/s3_bucket | n/a |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_acl.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_object.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
 | [random_pet.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
@@ -67,5 +66,5 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Description |
 |------|-------------|
-| <a name="output_bucket"></a> [bucket](#output\_bucket) | S3 bucket subscribed to Observe Lambda |
+| <a name="output_buckets"></a> [buckets](#output\_buckets) | S3 buckets subscribed to Observe Lambda |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/s3_bucket/main.tf
+++ b/examples/s3_bucket/main.tf
@@ -2,16 +2,10 @@ resource "random_pet" "run" {
   length = 2
 }
 
-resource "aws_s3_bucket" "bucket" {
-  count         = var.bucket_count
-  bucket        = format("%s-%d", random_pet.run.id, count.index)
-  force_destroy = true
-}
-
-resource "aws_s3_bucket_acl" "bucket" {
-  count  = var.bucket_count
-  bucket = aws_s3_bucket.bucket[count.index].id
-  acl    = "private"
+module "observe_s3_bucket" {
+  source      = "../..//modules/s3_bucket"
+  count       = var.bucket_count
+  bucket_name = format("%s-%d", random_pet.run.id, count.index)
 }
 
 module "observe_lambda" {
@@ -25,15 +19,15 @@ module "observe_lambda" {
 module "observe_lambda_s3_subscription" {
   source        = "../..//modules/s3_bucket_subscription"
   lambda        = module.observe_lambda.lambda_function
-  bucket_arns   = [for bucket in aws_s3_bucket.bucket : bucket.arn]
+  bucket_arns   = [for bucket in module.observe_s3_bucket : bucket.arn]
   filter_prefix = var.filter_prefix
   filter_suffix = var.filter_suffix
 }
 
 resource "aws_s3_object" "example" {
   depends_on = [module.observe_lambda_s3_subscription]
-  count      = length(aws_s3_bucket.bucket)
+  count      = length(module.observe_s3_bucket)
   key        = "example.json"
-  bucket     = aws_s3_bucket.bucket[count.index].id
+  bucket     = module.observe_s3_bucket[count.index].id
   content    = jsonencode({ hello = "world" })
 }

--- a/examples/s3_bucket/outputs.tf
+++ b/examples/s3_bucket/outputs.tf
@@ -1,4 +1,4 @@
-output "bucket" {
-  description = "S3 bucket subscribed to Observe Lambda"
-  value       = aws_s3_bucket.bucket
+output "buckets" {
+  description = "S3 buckets subscribed to Observe Lambda"
+  value       = module.observe_s3_bucket
 }

--- a/modules/s3_bucket/README.md
+++ b/modules/s3_bucket/README.md
@@ -1,0 +1,79 @@
+# AWS S3 Collection Bucket
+
+This module creates an S3 collection bucket, and is intended as a quick start
+for exporting logs out of AWS. The bucket has the appropriate permissions to
+be written to from as many AWS services as possible.
+
+## Usage
+
+```hcl
+module "observe_s3_bucket"
+  source      = "observeinc/lambda/aws//modules/s3_bucket"
+  bucket_name = random_pet.run.id
+}
+
+module "observe_lambda" {
+  source           = "observeinc/lambda/aws"
+  observe_customer = var.observe_customer
+  observe_token    = var.observe_token
+  observe_domain   = var.observe_domain
+  name             = random_pet.run.id
+}
+
+module "observe_lambda_s3_subscription" {
+  source      = "observeinc/lambda/aws//modules/s3_bucket_subscription"
+  lambda      = module.observe_lambda.lambda_function
+  bucket_arns = [aws_s3_bucket.bucket.arn]
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.7.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_redshift_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/redshift_service_account) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Bucket name | `string` | n/a | yes |
+| <a name="input_exported_prefix"></a> [exported\_prefix](#input\_exported\_prefix) | Key prefix which logs are to be written to | `string` | `""` | no |
+| <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | Destroy all objects when deleting bucket | `bool` | `true` | no |
+| <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
+| <a name="input_logging"></a> [logging](#input\_logging) | Enable S3 access log collection | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | S3 Bucket ARN |
+| <a name="output_id"></a> [id](#output\_id) | S3 Bucket ID |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## License
+
+Apache 2 Licensed. See LICENSE for full details.

--- a/modules/s3_bucket/main.tf
+++ b/modules/s3_bucket/main.tf
@@ -1,0 +1,167 @@
+locals {
+  bucket_arn      = "arn:aws:s3:::${var.bucket_name}"
+  aws_logs_arn    = "${local.bucket_arn}/${local.exported_prefix}AWSLogs/${data.aws_caller_identity.current.account_id}/*"
+  exported_prefix = var.exported_prefix != "" ? format("%s/", trimsuffix(var.exported_prefix, "/")) : ""
+}
+
+data "aws_caller_identity" "current" {}
+
+module "s3_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 3.7.0"
+
+  bucket        = var.bucket_name
+  acl           = "log-delivery-write"
+  force_destroy = var.force_destroy
+
+  lifecycle_rule = var.lifecycle_rule
+
+  logging = var.logging ? {
+    target_bucket = var.bucket_name
+    target_prefix = "${local.exported_prefix}S3ServerLogs/"
+  } : {}
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  attach_elb_log_delivery_policy = true
+  attach_lb_log_delivery_policy  = true
+  attach_policy                  = true
+  policy                         = data.aws_iam_policy_document.bucket.json
+
+  tags = var.tags
+}
+
+data "aws_redshift_service_account" "this" {}
+
+data "aws_iam_policy_document" "bucket" {
+  statement {
+    sid    = "AWSCloudTrailWrite"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      local.aws_logs_arn,
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+
+  statement {
+    sid    = "AWSCloudTrailAclCheck"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:GetBucketAcl",
+    ]
+
+    resources = [
+      local.bucket_arn,
+    ]
+  }
+
+  statement {
+    sid    = "AWSConfigWrite"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      local.aws_logs_arn,
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+
+  statement {
+    sid    = "AWSConfigAclCheck"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:GetBucketAcl",
+    ]
+
+    resources = [
+      local.bucket_arn,
+    ]
+  }
+
+  statement {
+    sid    = "AWSRedshiftWrite"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_redshift_service_account.this.arn]
+    }
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      local.aws_logs_arn,
+    ]
+  }
+
+  statement {
+    sid    = "AWSRedshiftAclCheck"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_redshift_service_account.this.arn]
+    }
+
+    actions = [
+      "s3:GetBucketAcl",
+    ]
+
+    resources = [
+      local.bucket_arn,
+    ]
+  }
+}

--- a/modules/s3_bucket/outputs.tf
+++ b/modules/s3_bucket/outputs.tf
@@ -1,0 +1,9 @@
+output "id" {
+  description = "S3 Bucket ID"
+  value       = module.s3_bucket.s3_bucket_id
+}
+
+output "arn" {
+  description = "S3 Bucket ARN"
+  value       = module.s3_bucket.s3_bucket_arn
+}

--- a/modules/s3_bucket/variables.tf
+++ b/modules/s3_bucket/variables.tf
@@ -1,0 +1,39 @@
+variable "bucket_name" {
+  description = "Bucket name"
+  type        = string
+}
+
+variable "exported_prefix" {
+  description = "Key prefix which logs are to be written to"
+  type        = string
+  nullable    = false
+  default     = ""
+}
+
+variable "logging" {
+  description = "Enable S3 access log collection"
+  type        = bool
+  nullable    = false
+  default     = false
+}
+
+variable "lifecycle_rule" {
+  description = "List of maps containing configuration of object lifecycle management."
+  type        = any
+  nullable    = false
+  default     = []
+}
+
+variable "force_destroy" {
+  description = "Destroy all objects when deleting bucket"
+  type        = bool
+  nullable    = false
+  default     = true
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  nullable    = false
+  default     = {}
+}

--- a/modules/s3_bucket/versions.tf
+++ b/modules/s3_bucket/versions.tf
@@ -2,7 +2,6 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws    = ">= 4.9"
-    random = ">= 3.0.0"
+    aws = ">= 4.9"
   }
 }


### PR DESCRIPTION
When configuring a bucket to trigger the Observe Lambda, there are many options that are commonly useful. This includes setting lifecycle rules or configuring permissions for services such as CloudWatch or CloudTrail to write to a prefix within the bucket.

Ths commit introduces the `s3_bucket` module, which is modelled after our current s3 bucket configuration in the `observeinc/collection/aws` module.