### PR TITLE
fix(cloudwatch_metrics): correct rule schedule expression

### DIFF
--- a/modules/cloudwatch_metrics/main.tf
+++ b/modules/cloudwatch_metrics/main.tf
@@ -39,7 +39,7 @@ resource "aws_iam_role_policy_attachment" "this" {
 resource "aws_cloudwatch_event_rule" "trigger" {
   name_prefix         = var.eventbridge_name_prefix
   description         = "Periodically trigger Observe Lambda to collect CloudWatch metrics"
-  schedule_expression = "cron(${var.interval / 60} * * * ? *)"
+  schedule_expression = var.interval == 60 ? "rate(1 minute)" : "rate(${var.interval / 60} minutes)"
   event_bus_name      = var.eventbridge_schedule_event_bus_name
 }
 

--- a/modules/cloudwatch_metrics/variables.tf
+++ b/modules/cloudwatch_metrics/variables.tf
@@ -35,8 +35,8 @@ variable "interval" {
   nullable    = false
   default     = 300
   validation {
-    condition     = var.interval >= 60 && var.interval < 3600
-    error_message = "interval must be greater than or equal to 60 and less than 3600."
+    condition     = var.interval >= 60 && var.interval <= 10800
+    error_message = "interval must be in [60, 10800] (1 minute to 3 hours)"
   }
 }
 


### PR DESCRIPTION

## What does this PR do?

The schedule previously ran once an hour. It now should do what the interval variable says it does

## Testing

I tested 1 minute, 5 minutes, and 3 hours
