### PR TITLE
fix(cloudwatch_metrics): revert to cron expression

### DIFF
--- a/modules/cloudwatch_metrics/variables.tf
+++ b/modules/cloudwatch_metrics/variables.tf
@@ -35,8 +35,8 @@ variable "interval" {
   nullable    = false
   default     = 300
   validation {
-    condition     = var.interval >= 60 && var.interval <= 10800
-    error_message = "interval must be in [60, 10800] (1 minute to 3 hours)"
+    condition     = (var.interval >= 60 && var.interval <= 60 * 60) || (var.interval >= 60 * 60 && var.interval <= 24 * 60 * 60 && var.interval % (60 * 60) == 0)
+    error_message = "interval must be minutely, up to an hour, or hourly, up to a day"
   }
 }
 


### PR DESCRIPTION
PR #62 fixed our schedule expression to fire at the correct cadence, but subtly changed the time at which the rule would trigger. The use of the `rate` function ensures a rule will trigger at regular intervals from rule creation. Given the nature of the data we are collecting, we want rules to trigger aligned to fixed time boundaries (e.g. every minute, every hour). This commit reintroduces a correct cron expression.