### PR TITLE
fix: update `required_providers` syntax

### DIFF
--- a/examples/cloudtrail/versions.tf
+++ b/examples/cloudtrail/versions.tf
@@ -2,8 +2,17 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws    = ">= 2.68"
-    random = ">= 3.0.0"
-    local  = ">= 2.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.68"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.0.0"
+    }
   }
 }

--- a/examples/s3_access_logs/versions.tf
+++ b/examples/s3_access_logs/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws    = ">= 3.75"
-    random = ">= 3.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.75"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
   }
 }

--- a/examples/s3_bucket/versions.tf
+++ b/examples/s3_bucket/versions.tf
@@ -2,7 +2,13 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws    = ">= 4.9"
-    random = ">= 3.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
   }
 }

--- a/examples/vpc_config/versions.tf
+++ b/examples/vpc_config/versions.tf
@@ -2,7 +2,14 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws    = ">= 3.75"
-    random = ">= 3.0.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.75"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
+    }
+
   }
 }

--- a/modules/cloudwatch_logs_subscription/versions.tf
+++ b/modules/cloudwatch_logs_subscription/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.68"
+    }
   }
 }

--- a/modules/s3_bucket/versions.tf
+++ b/modules/s3_bucket/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws = ">= 4.9"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.9"
+    }
   }
 }

--- a/modules/s3_bucket_subscription/versions.tf
+++ b/modules/s3_bucket_subscription/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.68"
+    }
   }
 }

--- a/modules/snapshot/versions.tf
+++ b/modules/snapshot/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.68"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 1.1.0"
 
   required_providers {
-    aws = ">= 2.68"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.68"
+    }
   }
 }


### PR DESCRIPTION
We no longer need terraform v0.12 compatibility, update syntax to appease tflint.