### PR TITLE
fix: declare Lambda's dependency on log group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -70,6 +70,7 @@ resource "aws_lambda_function" "this" {
   }
 
   depends_on = [
+    aws_cloudwatch_log_group.group,
     aws_iam_role_policy_attachment.lambda_logs,
     aws_iam_role_policy_attachment.vpc_access,
   ]


### PR DESCRIPTION
## What does this PR do?

Makes explicit the implicit dependency between the Lambda and the CloudWatch log group with `name = format("/aws/lambda/%s", var.name)`. 

## Motivation

This pattern of hardcoding the Lambda CWL naming scheme with `depends_on` is used to have Terraform manage a CloudWatch Logs log group for a Lambda. Lambdas don't take a log group, but if one already exists with the right name they'll just use it. 

Without `depends_on`, there is a (very unlikely) race condition. If the Lambda managed to be created and get invoked before Terraform created the log group, Terraform will hit a conflict that only `import` can resolve.

This also ensures that during a `terraform destroy` that the graph is cleaned up in the reverse direction and the Lambda is destroyed before the log group. This is potentially important, because the Lambda will re-create the log group when invoked.

## Testing

`terraform validate` is the most testing we can do here.