### PR TITLE
feat: add `log_group_name` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_lambda_function"></a> [lambda\_function](#output\_lambda\_function) | Observe Lambda function |
+| <a name="output_log_group_name"></a> [log\_group\_name](#output\_log\_group\_name) | The name of the CloudWatch log group where logs for the Lambda will be written. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "lambda_function" {
   description = "Observe Lambda function"
   value       = aws_lambda_function.this
 }
+
+output "log_group_name" {
+  description = "The name of the CloudWatch log group where logs for the Lambda will be written."
+  value       = aws_cloudwatch_log_group.group.name
+}


### PR DESCRIPTION
## What does this PR do?

Exposes the CloudWatch log group name as an output.

## Motivation

Allows callers of this module to wire up this log group with a filter to a Kinesis Firehose delivery stream, e.g.,:

https://github.com/observeinc/terraform-aws-kinesis-firehose/tree/main/modules/cloudwatch_logs_subscription

Currently, because the Lambda implicitly depends on this (even with #68), callers have to hardcode this `/aws/lambda/*` pattern. We should encapsulate the hack here.

## Testing

`terraform validate` ensures this reference is valid and is sufficient proof that this works.