### PR TITLE
feat: support OBSERVE_COLLECTION_ENDPOINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Terraform module which sets up a Lambda to forward event data towards Observe.
 module "observe_lambda" {
   source = "observeinc/lambda/aws"
 
-  name                = "observe-lambda"
-  observe_customer    = "<id>"
-  observe_token       = "<token>"
+  name                           = "observe-lambda"
+  observe_collection_endpoint    = "https://<customerid>.collect.observeinc.com"
+  observe_token                  = "<token>"
 }
 ```
 
@@ -76,8 +76,9 @@ No modules.
 | <a name="input_lambda_version"></a> [lambda\_version](#input\_lambda\_version) | Version of lambda binary to use | `string` | `"latest"` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | The amount of memory that your function has access to. Increasing the function's memory also increases its CPU allocation.<br>The default value is 128 MB. The value must be a multiple of 64 MB. | `number` | `128` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of Lambda resource | `string` | n/a | yes |
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain | `string` | `"observeinc.com"` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | `null` | no |
+| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID. Deprecated, please use observe\_collection\_endpoint instead | `string` | `null` | no |
+| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe domain. Deprecated, please use observe\_collection\_endpoint instead | `string` | `"observeinc.com"` | no |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe Token | `string` | n/a | yes |
 | <a name="input_reserved_concurrent_executions"></a> [reserved\_concurrent\_executions](#input\_reserved\_concurrent\_executions) | The number of simultaneous executions to reserve for the function. | `number` | `100` | no |
 | <a name="input_retention_in_days"></a> [retention\_in\_days](#input\_retention\_in\_days) | Retention in days of cloudwatch log group | `number` | `14` | no |

--- a/examples/cloudtrail/README.md
+++ b/examples/cloudtrail/README.md
@@ -58,8 +58,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `null` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/cloudtrail/main.tf
+++ b/examples/cloudtrail/main.tf
@@ -23,11 +23,10 @@ module "cloudtrail" {
 }
 
 module "observe_lambda" {
-  source           = "../.."
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
-  name             = random_pet.run.id
+  source                      = "../.."
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
+  name                        = random_pet.run.id
 }
 
 module "observe_lambda_s3_subscription" {

--- a/examples/cloudtrail/variables.tf
+++ b/examples/cloudtrail/variables.tf
@@ -1,15 +1,9 @@
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
 }
 
 variable "observe_token" {
   description = "Observe token"
   type        = string
-}
-
-variable "observe_domain" {
-  description = "Observe Domain"
-  type        = string
-  default     = null
 }

--- a/examples/s3_access_logs/README.md
+++ b/examples/s3_access_logs/README.md
@@ -60,8 +60,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_name"></a> [name](#input\_name) | Lambda name | `string` | n/a | yes |
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `null` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/s3_access_logs/main.tf
+++ b/examples/s3_access_logs/main.tf
@@ -27,11 +27,10 @@ resource "aws_s3_bucket_acl" "access_logs" {
 }
 
 module "observe_lambda" {
-  source           = "../.."
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
-  name             = var.name
+  source                      = "../.."
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
+  name                        = var.name
 }
 
 module "observe_lambda_s3_subscription" {

--- a/examples/s3_access_logs/variables.tf
+++ b/examples/s3_access_logs/variables.tf
@@ -1,17 +1,11 @@
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
 }
 
 variable "observe_token" {
   description = "Observe token"
   type        = string
-}
-
-variable "observe_domain" {
-  description = "Observe Domain"
-  type        = string
-  default     = null
 }
 
 variable "name" {

--- a/examples/s3_bucket/README.md
+++ b/examples/s3_bucket/README.md
@@ -58,8 +58,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | <a name="input_bucket_count"></a> [bucket\_count](#input\_bucket\_count) | Number of buckets to create and subscribe. | `number` | `1` | no |
 | <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | Specifies object key name prefix on S3 bucket notifications. | `string` | `null` | no |
 | <a name="input_filter_suffix"></a> [filter\_suffix](#input\_filter\_suffix) | Specifies object key name suffix on S3 bucket notifications. | `string` | `null` | no |
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `null` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/s3_bucket/main.tf
+++ b/examples/s3_bucket/main.tf
@@ -9,11 +9,10 @@ module "observe_s3_bucket" {
 }
 
 module "observe_lambda" {
-  source           = "../.."
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
-  name             = random_pet.run.id
+  source                      = "../.."
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
+  name                        = random_pet.run.id
 }
 
 module "observe_lambda_s3_subscription" {

--- a/examples/s3_bucket/variables.tf
+++ b/examples/s3_bucket/variables.tf
@@ -1,17 +1,11 @@
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
 }
 
 variable "observe_token" {
   description = "Observe token"
   type        = string
-}
-
-variable "observe_domain" {
-  description = "Observe Domain"
-  type        = string
-  default     = null
 }
 
 variable "bucket_count" {

--- a/examples/vpc_config/README.md
+++ b/examples/vpc_config/README.md
@@ -61,8 +61,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID | `string` | n/a | yes |
-| <a name="input_observe_domain"></a> [observe\_domain](#input\_observe\_domain) | Observe Domain | `string` | `"observeinc.com"` | no |
+| <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | n/a | yes |
 | <a name="input_observe_token"></a> [observe\_token](#input\_observe\_token) | Observe token | `string` | n/a | yes |
 
 ## Outputs

--- a/examples/vpc_config/main.tf
+++ b/examples/vpc_config/main.tf
@@ -10,10 +10,9 @@ resource "random_pet" "run" {
 module "observe_lambda" {
   source = "../.."
 
-  name             = random_pet.run.id
-  observe_domain   = var.observe_domain
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
+  name                        = random_pet.run.id
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
 
   vpc_config = {
     subnets         = [aws_subnet.private]

--- a/examples/vpc_config/variables.tf
+++ b/examples/vpc_config/variables.tf
@@ -1,15 +1,9 @@
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
 }
 
 variable "observe_token" {
   description = "Observe token"
   type        = string
-}
-
-variable "observe_domain" {
-  description = "Observe Domain"
-  type        = string
-  default     = "observeinc.com"
 }

--- a/main.tf
+++ b/main.tf
@@ -54,8 +54,8 @@ resource "aws_lambda_function" "this" {
 
   environment {
     variables = merge({
-      OBSERVE_URL   = format("https://%s.collect.%s/v1/http", var.observe_customer, var.observe_domain)
-      OBSERVE_TOKEN = var.observe_token
+      OBSERVE_COLLECTION_ENDPOINT = var.observe_collection_endpoint != null ? var.observe_collection_endpoint : format("https://%s.collect.%s", var.observe_customer, var.observe_domain)
+      OBSERVE_TOKEN               = var.observe_token
       }, length(var.lambda_s3_custom_rules) > 0 ? {
       S3_CUSTOM_RULES = base64encode(jsonencode(var.lambda_s3_custom_rules))
       } : {}

--- a/modules/cloudwatch_logs_subscription/README.md
+++ b/modules/cloudwatch_logs_subscription/README.md
@@ -19,11 +19,10 @@ resource "aws_cloudwatch_log_group" "group" {
 }
 
 module "observe_lambda" {
-  source           = "observeinc/lambda/aws"
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
-  name             = random_pet.run.id
+  source                      = "observeinc/lambda/aws"
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
+  name                        = random_pet.run.id
 }
 
 module "observe_lambda_cloudwatch_logs_subscription" {

--- a/modules/cloudwatch_metrics/README.md
+++ b/modules/cloudwatch_metrics/README.md
@@ -15,11 +15,10 @@ Lambda to ensure that all requested endpoints are accessible.
 
 ```hcl
 module "observe_lambda" {
-  source           = "observeinc/lambda/aws"
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
-  name             = random_pet.run.id
+  source                      = "observeinc/lambda/aws"
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
+  name                        = random_pet.run.id
 }
 
 module "cloudwatch_metrics" {

--- a/modules/s3_bucket/README.md
+++ b/modules/s3_bucket/README.md
@@ -13,11 +13,10 @@ module "observe_s3_bucket"
 }
 
 module "observe_lambda" {
-  source           = "observeinc/lambda/aws"
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
-  name             = random_pet.run.id
+  source                      = "observeinc/lambda/aws"
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
+  name                        = random_pet.run.id
 }
 
 module "observe_lambda_s3_subscription" {

--- a/modules/s3_bucket_subscription/README.md
+++ b/modules/s3_bucket_subscription/README.md
@@ -14,11 +14,10 @@ resource "aws_s3_bucket" "bucket" {
 }
 
 module "observe_lambda" {
-  source           = "observeinc/lambda/aws"
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
-  name             = random_pet.run.id
+  source                      = "observeinc/lambda/aws"
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
+  name                        = random_pet.run.id
 }
 
 module "observe_lambda_s3_subscription" {

--- a/modules/snapshot/README.md
+++ b/modules/snapshot/README.md
@@ -9,11 +9,10 @@ to ensure that all requested endpoints are accessible.
 
 ```hcl
 module "observe_lambda" {
-  source           = "observeinc/lambda/aws"
-  observe_customer = var.observe_customer
-  observe_token    = var.observe_token
-  observe_domain   = var.observe_domain
-  name             = random_pet.run.id
+  source                      = "observeinc/lambda/aws"
+  observe_collection_endpoint = var.observe_collection_endpoint
+  observe_token               = var.observe_token
+  name                        = random_pet.run.id
 }
 
 module "observe_lambda_snapshot" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,9 +3,20 @@ variable "name" {
   type        = string
 }
 
-variable "observe_customer" {
-  description = "Observe Customer ID"
+variable "observe_collection_endpoint" {
+  description = "Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com"
   type        = string
+  default     = null
+  validation {
+    condition     = var.observe_collection_endpoint == null || can(regex("^https://.*$", var.observe_collection_endpoint))
+    error_message = "Endpoint must be a valid HTTPS URL."
+  }
+}
+
+variable "observe_customer" {
+  description = "Observe Customer ID. Deprecated, please use observe_collection_endpoint instead"
+  type        = string
+  default     = null
 }
 
 variable "observe_token" {
@@ -18,9 +29,8 @@ variable "observe_token" {
   }
 }
 
-# Optional input variables
 variable "observe_domain" {
-  description = "Observe domain"
+  description = "Observe domain. Deprecated, please use observe_collection_endpoint instead"
   type        = string
   nullable    = false
   default     = "observeinc.com"


### PR DESCRIPTION
This commit adds support for `collection_endpoint`, and deprecates both `customer` and `domain`.