### PR TITLE
fix(snapshot): event target depends on snapshot role attachment

### DIFF
--- a/modules/snapshot/README.md
+++ b/modules/snapshot/README.md
@@ -96,12 +96,14 @@ module "observe_lambda_snapshot_b" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.9.1 |
 
 ## Modules
 
@@ -117,6 +119,7 @@ No modules.
 | [aws_iam_role_policy_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_lambda_invocation.snapshot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_invocation) | resource |
 | [aws_lambda_permission.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [time_sleep.wait_after_policy_attachment](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_arn.function](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 | [aws_arn.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 

--- a/modules/snapshot/main.tf
+++ b/modules/snapshot/main.tf
@@ -41,6 +41,12 @@ resource "aws_cloudwatch_event_rule" "trigger" {
   event_bus_name      = var.eventbridge_schedule_event_bus_name
 }
 
+resource "time_sleep" "wait_after_policy_attachment" {
+  depends_on = [aws_iam_role_policy_attachment.this]
+
+  create_duration = "3m"
+}
+
 resource "aws_cloudwatch_event_target" "target" {
   arn  = var.lambda.lambda_function.arn
   rule = aws_cloudwatch_event_rule.trigger.name
@@ -51,6 +57,10 @@ resource "aws_cloudwatch_event_target" "target" {
       overrides = var.overrides
     }
   })
+
+  depends_on = [
+    time_sleep.wait_after_policy_attachment,
+  ]
 }
 
 resource "aws_lambda_permission" "this" {

--- a/modules/snapshot/versions.tf
+++ b/modules/snapshot/versions.tf
@@ -6,5 +6,10 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.68"
     }
+
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9.1"
+    }
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition when invoke_snapshot_on_start_enabled is true. Previously, initial snapshot could be triggered before the policy allowing all the snapshot actions was successfully attached to the lambda role, resulting in initial snapshot failure. Now, the execution trigger depends on policy attachment and adds a sleep based on evidence that aws_iam_policy_attachment can succeed before snapshot starts and the snapshot will somehow still run into a 403 error partway through.

## Testing

Pointed https://github.com/observeinc/terraform-aws-collection/blob/main/lambda.tf at my changed local copy of the modules, used `examples/simple/` to spin up a collection stack with the fix.
