### PR TITLE
fix: address snapshot race

### DIFF
--- a/modules/snapshot/README.md
+++ b/modules/snapshot/README.md
@@ -94,13 +94,13 @@ module "observe_lambda_snapshot_b" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.73 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.73 |
 
 ## Modules
 

--- a/modules/snapshot/main.tf
+++ b/modules/snapshot/main.tf
@@ -51,6 +51,8 @@ resource "aws_cloudwatch_event_target" "target" {
       overrides = var.overrides
     }
   })
+
+  depends_on = [aws_lambda_permission.this]
 }
 
 resource "aws_lambda_permission" "this" {
@@ -68,4 +70,3 @@ resource "aws_lambda_invocation" "snapshot" {
 
   input = aws_cloudwatch_event_target.target.input
 }
-

--- a/modules/snapshot/versions.tf
+++ b/modules/snapshot/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.68"
+      version = ">= 3.73"
     }
   }
 }


### PR DESCRIPTION
We need to ensure we only invoke the snapshot lambda once we have the appropriate permission. Since we depend on the eventbridge target, we should ensure the target is only installed after the lambda permission has been configured.

We also update the version constraint on `aws` to reflect the use of `aws_lambda_invocation` which was only introduced in 3.72.0