### PR TITLE
fix: Go 1.x runtime is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ No modules.
 | <a name="input_lambda_envvars"></a> [lambda\_envvars](#input\_lambda\_envvars) | Environment variables | `map(any)` | `{}` | no |
 | <a name="input_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#input\_lambda\_iam\_role\_arn) | ARN of IAM role to use for Lambda | `string` | `""` | no |
 | <a name="input_lambda_s3_custom_rules"></a> [lambda\_s3\_custom\_rules](#input\_lambda\_s3\_custom\_rules) | List of rules to evaluate how to upload a given S3 object to Observe | <pre>list(object({<br>    pattern = string<br>    headers = map(string)<br>  }))</pre> | `[]` | no |
-| <a name="input_lambda_version"></a> [lambda\_version](#input\_lambda\_version) | Version of lambda binary to use | `string` | `"latest"` | no |
+| <a name="input_lambda_version"></a> [lambda\_version](#input\_lambda\_version) | Version of lambda binary to use | `string` | `"arm64/latest"` | no |
 | <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | The amount of memory that your function has access to. Increasing the function's memory also increases its CPU allocation.<br>The default value is 128 MB. The value must be a multiple of 64 MB. | `number` | `128` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of Lambda resource | `string` | n/a | yes |
 | <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -39,7 +39,7 @@ variable "observe_domain" {
 variable "lambda_version" {
   description = "Version of lambda binary to use"
   type        = string
-  default     = "latest"
+  default     = "arm64/latest"
   nullable    = false
 }
 


### PR DESCRIPTION
## What does this PR do?

Migrates off of Go 1.x runtime

## Motivation

Go 1.x is deprecated

![image](https://github.com/observeinc/terraform-aws-lambda/assets/131207535/8a761414-dea5-461e-a70b-fe7fe19c3bf4)

## Testing

Did a terraform apply and verified the Go runtime changed

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.observe_collection.module.observe_lambda.aws_lambda_function.this will be updated in-place
  ~ resource "aws_lambda_function" "this" {
      ~ architectures                  = [
          - "x86_64",
          + "arm64",
        ]
      ~ handler                        = "main" -> "bootstrap"
        id                             = "colin3"
      ~ last_modified                  = "2023-10-03T16:04:12.112+0000" -> (known after apply)
      ~ runtime                        = "go1.x" -> "provided.al2"
      ~ s3_key                         = "lambda/observer/latest.zip" -> "lambda/observer/arm64/latest.zip"
        tags                           = {}
        # (19 unchanged attributes hidden)

      ~ environment {
          ~ variables = {
              + "OBSERVE_COLLECTION_ENDPOINT" = "https://130348791288.collect.observe-eng.com"
              - "OBSERVE_URL"                 = "https://130348791288.collect.observe-eng.com/v1/http" -> null
                # (1 unchanged element hidden)
            }
        }

        # (2 unchanged blocks hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

![image](https://github.com/observeinc/terraform-aws-lambda/assets/131207535/0b25fdf6-7258-4f7a-8ef6-4e69a3d02da5)

