### PR TITLE
fix: Fix S3 Bucket Notification Configuration Validation Error OBSSD-612

### DIFF
--- a/modules/s3_bucket_subscription/main.tf
+++ b/modules/s3_bucket_subscription/main.tf
@@ -28,6 +28,7 @@ resource "aws_s3_bucket_notification" "notification" {
     filter_prefix       = var.filter_prefix
     filter_suffix       = var.filter_suffix
   }
+  depends_on = [aws_lambda_permission.allow_bucket]
 }
 
 resource "aws_iam_policy" "s3_bucket_read" {


### PR DESCRIPTION
## What does this PR do?

This pull request addresses `InvalidArgument` encountered creating the S3 bucket notification configuration. The error: 
```
Error: creating S3 Bucket (<BUCKET>) Notification: operation error S3: PutBucketNotificationConfiguration, https response error StatusCode: 400, RequestID: <ID>, HostID: <HOST>, api error InvalidArgument: Unable to
validate the following destination configurations

  with module.<MODULE>.module.observe_lambda_s3_subscription.aws_s3_bucket_notification.notification[0],
  on .terraform/modules/<MODULE>.observe_lambda_s3_subscription/modules/s3_bucket_subscription/main.tf line 20, in
  resource "aws_s3_bucket_notification" "notification":
  20: resource "aws_s3_bucket_notification" "notification" {
```
The error occurred because `aws_lambda_permission` and `aws_s3_bucket_notification` were being created dynamically using count, without guaranteeing the correct creation order. S3 requires that the Lambda invoke permission `(lambda:InvokeFunction)` already exist and be fully propagated before the `PutBucketNotificationConfiguration` API call is made. Without this sequencing, AWS fails to validate the destination configuration, resulting in an `InvalidArgument` error during apply.

This update ensures that the S3 bucket notification is explicitly dependent on the Lambda permission using depends_on, enforcing the correct provisioning order.

## Testing

Validated deploying new Lambda and ensuring InvalidArgument was not encountered.