### PR TITLE
Update role attachment count

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -202,7 +202,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "kms_decrypt" {
-  count      = length(aws_iam_policy.kms_decrypt)
+  count      = count = var.kms_key != null ? 1 : 0
   role       = local.lambda_iam_role_name
   policy_arn = aws_iam_policy.kms_decrypt[count.index].arn
 }

--- a/main.tf
+++ b/main.tf
@@ -202,7 +202,7 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "kms_decrypt" {
-  count      = count = var.kms_key != null ? 1 : 0
+  count      = var.kms_key != null ? 1 : 0
   role       = local.lambda_iam_role_name
   policy_arn = aws_iam_policy.kms_decrypt[count.index].arn
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the `count` argument on `aws_iam_role_policy_attachment.kms_decrypt` (line 205 in `main.tf`) to use the same static condition as the policy resource it references, instead of `length()` on the resource itself.

```diff
- count      = length(aws_iam_policy.kms_decrypt)
+ count      = var.kms_key != null ? 1 : 0
```

This matches the condition already used by `aws_iam_policy.kms_decrypt` on line 177.

## Motivation

`length(aws_iam_policy.kms_decrypt)` references a resource attribute that Terraform cannot resolve until apply. This causes `terraform import` and `terraform state` commands to fail with:

```javascript
Error: Invalid count argument
  count = length(aws_iam_policy.kms_decrypt)
  The "count" value depends on resource attributes that cannot be determined until apply
```

This blocks all terraform state operations in any workspace that includes this module.

## Testing

- Confirmed the error reproduces on Terraform 1.14.3 with `observeinc/lambda/aws` v3.6.0 when `kms_key = null`
- Applied the fix locally and verified `terraform plan/apply`, `terraform import`, and `terraform state rm` all succeed
- No functional change — the condition evaluates identically to the existing `aws_iam_policy.kms_decrypt` count
