### PR TITLE
fix: replace deprecated AWS provider attributes and inline blocks

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -95,8 +95,8 @@ jobs:
       - name: Install pre-commit dependencies
         run: |
           pip install pre-commit
-          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.15.0/terraform-docs-v0.15.0-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
-          curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
+          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.21.0/terraform-docs-v0.21.0-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz terraform-docs && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
+          curl -L "https://github.com/terraform-linters/tflint/releases/download/v0.63.1/tflint_linux_amd64.zip" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
       - name: Execute pre-commit
         # Run all pre-commit checks on max version supported
         if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,49 @@
+# [4.0.0](https://github.com/observeinc/terraform-aws-lambda/compare/v3.8.0...v4.0.0) (Unreleased)
+
+
+### ⚠ BREAKING CHANGES
+
+* **providers**: Minimum AWS provider version raised from `>= 2.68` to `>= 6.0` across all modules and examples. Users on AWS provider v5.x or below must upgrade before using this module version. The v6.0 breaking changes do not affect any resources managed by this module — see the [AWS provider v6.0 changelog](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md) for the full list.
+
+* **modules/s3_bucket**: `terraform-aws-modules/s3-bucket` dependency upgraded from `~> 3.7.0` to `~> 5.0`. After updating, run `terraform init -upgrade` to fetch the new module version. The input variable interface is unchanged for all inputs used by this module (`acl`, `logging`, `lifecycle_rule`, `server_side_encryption_configuration`, `attach_policy`, `attach_elb_log_delivery_policy`, `attach_lb_log_delivery_policy`). The v5 module also aligns with the `aws >= 6.0` provider requirement and raises the minimum Terraform version for this module to `>= 1.10`.
+
+
+### Bug Fixes
+
+* Replace deprecated `data.aws_region.current.id` attribute with `.region` in `main.tf` — in AWS provider v6.0, `.id` and `.name` are both deprecated in favor of `.region` ([OBSSD-4274](https://observe.atlassian.net/browse/OBSSD-4274))
+
+
+### Improvements
+
+* **main.tf**: Convert all IAM policy inline documents from heredoc (`<<EOF`) to `jsonencode()`. Functionally identical — eliminates fragile mixed heredoc+interpolation patterns and improves readability.
+* **modules/s3_bucket_subscription**: Convert IAM policy heredoc to `jsonencode()`.
+* **examples/s3_access_logs**: Replace deprecated inline `logging {}` block on `aws_s3_bucket` with standalone `aws_s3_bucket_logging` resource (deprecated in AWS provider v4).
+* **examples/vpc_config**: Replace deprecated inline `egress {}` block on `aws_security_group` with standalone `aws_vpc_security_group_egress_rule` resource (deprecated in AWS provider v5).
+* **ci**: Update terraform-docs in CI workflow from v0.15.0 to v0.21.0. Pin tflint to v0.63.1 with a direct download URL (replaces fragile `releases/latest` regex).
+* **examples/cloudtrail**: Bump `cloudposse/cloudtrail/aws` from `0.15.0` to `0.24.0` and `cloudposse/cloudtrail-s3-bucket/aws` from `0.15.0` to `0.32.0`. Previous versions had stale git references in the Terraform registry that prevented CI validation.
+* **examples/s3_bucket, examples/cloudtrail**: Raise `required_version` to `>= 1.10`. Terraform versions below 1.10 cannot resolve SHA-based `ref=` git references used by newer Terraform registry module entries, causing `terraform init` to fail in CI.
+
+
 # [3.8.0](https://github.com/observeinc/terraform-aws-lambda/compare/v3.7.0...v3.8.0) (2026-02-24)
 
 
 ### Features
 
 * Update Lambda Runtime to provided.al2023 ([3698b74](https://github.com/observeinc/terraform-aws-lambda/commit/3698b74e42bb955d90fe4688609243dac70a350e))
+
+
+
+# [3.7.0](https://github.com/observeinc/terraform-aws-lambda/compare/v3.6.0...v3.7.0) (2025-05-07)
+
+
+### Bug Fixes
+
+* Fix S3 Bucket Notification Configuration Validation Error OBSSD-612 ([a708fc6](https://github.com/observeinc/terraform-aws-lambda/commit/a708fc6f17fadf1330c048d4165a1a3385de8a9b))
+
+
+### Features
+
+* Update for apigatewayv2 ([a191b9c](https://github.com/observeinc/terraform-aws-lambda/commit/a191b9c8678d9f2c3aecfce14e6d0a5d8e7371fb))
 
 
 

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ This repository contains examples of how to solve for concrete usecases:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -72,13 +72,13 @@ No modules.
 | <a name="input_dead_letter_queue_destination"></a> [dead\_letter\_queue\_destination](#input\_dead\_letter\_queue\_destination) | Send failed events/function executions to a dead letter queue arn sns or sqs | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | Lambda description | `string` | `"Lambda function to forward events towards Observe"` | no |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `"observe-lambda-"` | no |
-| <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | The AWS Key Management Service (AWS KMS) key that's used to encrypt your<br>function's environment variables at rest. Additionally, the Observe Token<br>will be encrypted in transit. | `object({ arn = string })` | `null` | no |
-| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the AWS Key Management Service (AWS KMS) key that's used to encrypt your function's environment variables.<br>If it's not provided, AWS Lambda uses a default service key. Deprecated, please use kms\_key instead" | `string` | `""` | no |
+| <a name="input_kms_key"></a> [kms\_key](#input\_kms\_key) | The AWS Key Management Service (AWS KMS) key that's used to encrypt your<br/>function's environment variables at rest. Additionally, the Observe Token<br/>will be encrypted in transit. | `object({ arn = string })` | `null` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN of the AWS Key Management Service (AWS KMS) key that's used to encrypt your function's environment variables.<br/>If it's not provided, AWS Lambda uses a default service key. Deprecated, please use kms\_key instead" | `string` | `""` | no |
 | <a name="input_lambda_envvars"></a> [lambda\_envvars](#input\_lambda\_envvars) | Environment variables | `map(any)` | `{}` | no |
 | <a name="input_lambda_iam_role_arn"></a> [lambda\_iam\_role\_arn](#input\_lambda\_iam\_role\_arn) | ARN of IAM role to use for Lambda | `string` | `""` | no |
-| <a name="input_lambda_s3_custom_rules"></a> [lambda\_s3\_custom\_rules](#input\_lambda\_s3\_custom\_rules) | List of rules to evaluate how to upload a given S3 object to Observe | <pre>list(object({<br>    pattern = string<br>    headers = map(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_lambda_s3_custom_rules"></a> [lambda\_s3\_custom\_rules](#input\_lambda\_s3\_custom\_rules) | List of rules to evaluate how to upload a given S3 object to Observe | <pre>list(object({<br/>    pattern = string<br/>    headers = map(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_lambda_version"></a> [lambda\_version](#input\_lambda\_version) | Version of lambda binary to use | `string` | `"arm64/latest"` | no |
-| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | The amount of memory that your function has access to. Increasing the function's memory also increases its CPU allocation.<br>The value must be a multiple of 64 MB. The maximum is 10,240 MB. | `number` | `2048` | no |
+| <a name="input_memory_size"></a> [memory\_size](#input\_memory\_size) | The amount of memory that your function has access to. Increasing the function's memory also increases its CPU allocation.<br/>The value must be a multiple of 64 MB. The maximum is 10,240 MB. | `number` | `2048` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of Lambda resource | `string` | n/a | yes |
 | <a name="input_observe_collection_endpoint"></a> [observe\_collection\_endpoint](#input\_observe\_collection\_endpoint) | Observe Collection Endpoint, e.g https://123456789012.collect.observeinc.com | `string` | `null` | no |
 | <a name="input_observe_customer"></a> [observe\_customer](#input\_observe\_customer) | Observe Customer ID. Deprecated, please use observe\_collection\_endpoint instead | `string` | `null` | no |
@@ -92,8 +92,8 @@ No modules.
 | <a name="input_s3_object_version"></a> [s3\_object\_version](#input\_s3\_object\_version) | S3 object version for lambda binary | `string` | `""` | no |
 | <a name="input_s3_regional_buckets"></a> [s3\_regional\_buckets](#input\_s3\_regional\_buckets) | Map of AWS regions to lambda hosting S3 buckets | `map(any)` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
-| <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time that Lambda allows a function to run before stopping it.<br>The maximum allowed value is 900 seconds. | `number` | `120` | no |
-| <a name="input_vpc_config"></a> [vpc\_config](#input\_vpc\_config) | VPC Config | <pre>object({<br>    security_groups = list(object({<br>      id = string<br>    }))<br>    subnets = list(object({<br>      arn = string<br>      id  = string<br>    }))<br>  })</pre> | `null` | no |
+| <a name="input_timeout"></a> [timeout](#input\_timeout) | The amount of time that Lambda allows a function to run before stopping it.<br/>The maximum allowed value is 900 seconds. | `number` | `120` | no |
+| <a name="input_vpc_config"></a> [vpc\_config](#input\_vpc\_config) | VPC Config | <pre>object({<br/>    security_groups = list(object({<br/>      id = string<br/>    }))<br/>    subnets = list(object({<br/>      arn = string<br/>      id  = string<br/>    }))<br/>  })</pre> | `null` | no |
 
 ## Outputs
 

--- a/examples/cloudtrail/README.md
+++ b/examples/cloudtrail/README.md
@@ -28,8 +28,8 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
@@ -43,8 +43,8 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | cloudposse/cloudtrail/aws | 0.15.0 |
-| <a name="module_cloudtrail_s3_bucket"></a> [cloudtrail\_s3\_bucket](#module\_cloudtrail\_s3\_bucket) | cloudposse/cloudtrail-s3-bucket/aws | 0.15.0 |
+| <a name="module_cloudtrail"></a> [cloudtrail](#module\_cloudtrail) | cloudposse/cloudtrail/aws | 0.24.0 |
+| <a name="module_cloudtrail_s3_bucket"></a> [cloudtrail\_s3\_bucket](#module\_cloudtrail\_s3\_bucket) | cloudposse/cloudtrail-s3-bucket/aws | 0.32.0 |
 | <a name="module_observe_lambda"></a> [observe\_lambda](#module\_observe\_lambda) | ../.. | n/a |
 | <a name="module_observe_lambda_s3_subscription"></a> [observe\_lambda\_s3\_subscription](#module\_observe\_lambda\_s3\_subscription) | ../..//modules/s3_bucket_subscription | n/a |
 

--- a/examples/cloudtrail/main.tf
+++ b/examples/cloudtrail/main.tf
@@ -6,14 +6,14 @@ resource "random_pet" "run" {
 
 module "cloudtrail_s3_bucket" {
   source        = "cloudposse/cloudtrail-s3-bucket/aws"
-  version       = "0.15.0"
+  version       = "0.32.0"
   name          = random_pet.run.id
   force_destroy = true
 }
 
 module "cloudtrail" {
   source                        = "cloudposse/cloudtrail/aws"
-  version                       = "0.15.0"
+  version                       = "0.24.0"
   name                          = random_pet.run.id
   enable_log_file_validation    = true
   include_global_service_events = true

--- a/examples/cloudtrail/versions.tf
+++ b/examples/cloudtrail/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.1"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.68"
+      version = ">= 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3_access_logs/README.md
+++ b/examples/s3_access_logs/README.md
@@ -29,15 +29,15 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -54,6 +54,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | [aws_s3_bucket.monitored](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_acl.monitored](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_logging.access_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 
 ## Inputs
 

--- a/examples/s3_access_logs/main.tf
+++ b/examples/s3_access_logs/main.tf
@@ -11,14 +11,14 @@ resource "aws_s3_bucket_acl" "monitored" {
 }
 
 resource "aws_s3_bucket" "access_logs" {
-  bucket = var.name
-
-  logging {
-    target_bucket = aws_s3_bucket.monitored.id
-    target_prefix = "log/"
-  }
-
+  bucket        = var.name
   force_destroy = true
+}
+
+resource "aws_s3_bucket_logging" "access_logs" {
+  bucket        = aws_s3_bucket.access_logs.id
+  target_bucket = aws_s3_bucket.monitored.id
+  target_prefix = "log/"
 }
 
 resource "aws_s3_bucket_acl" "access_logs" {

--- a/examples/s3_access_logs/versions.tf
+++ b/examples/s3_access_logs/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.1"
+  required_version = ">= 1.1"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.75"
+      version = ">= 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3_bucket/README.md
+++ b/examples/s3_bucket/README.md
@@ -25,15 +25,15 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules

--- a/examples/s3_bucket/versions.tf
+++ b/examples/s3_bucket/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.1"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/vpc_config/README.md
+++ b/examples/vpc_config/README.md
@@ -23,15 +23,15 @@ Note that this will create AWS resources - once you are done, run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.75 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.75 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
@@ -55,6 +55,7 @@ Note that this will create AWS resources - once you are done, run `terraform des
 | [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
 | [aws_vpc.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+| [aws_vpc_security_group_egress_rule.allow_all_outbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [random_pet.run](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 
 ## Inputs

--- a/examples/vpc_config/versions.tf
+++ b/examples/vpc_config/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.1"
+  required_version = ">= 1.1"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.75"
+      version = ">= 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/vpc_config/vpc.tf
+++ b/examples/vpc_config/vpc.tf
@@ -71,11 +71,10 @@ resource "aws_subnet" "private" {
 resource "aws_security_group" "allow_outbound" {
   vpc_id = aws_vpc.main.id
   tags   = local.tags
+}
 
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_vpc_security_group_egress_rule" "allow_all_outbound" {
+  security_group_id = aws_security_group.allow_outbound.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,8 @@
 locals {
-  default_lambda_bucket = format("observeinc-%s", data.aws_region.current.id)
+  default_lambda_bucket = format("observeinc-%s", data.aws_region.current.region)
   lambda_iam_role_arn   = var.lambda_iam_role_arn != "" ? var.lambda_iam_role_arn : aws_iam_role.lambda[0].arn
   lambda_iam_role_name  = regex(".*role/(?P<role_name>.*)$", local.lambda_iam_role_arn)["role_name"]
-  s3_bucket             = var.s3_bucket != "" ? var.s3_bucket : lookup(var.s3_regional_buckets, data.aws_region.current.id, local.default_lambda_bucket)
+  s3_bucket             = var.s3_bucket != "" ? var.s3_bucket : lookup(var.s3_regional_buckets, data.aws_region.current.region, local.default_lambda_bucket)
   s3_key                = var.s3_key != "" ? var.s3_key : join("/", [var.s3_key_prefix, format("%s.zip", var.lambda_version)])
   observe_token         = var.kms_key != null ? aws_kms_ciphertext.token[0].ciphertext_blob : var.observe_token
   goarch = lookup(
@@ -86,23 +86,17 @@ resource "aws_lambda_function" "this" {
 }
 
 resource "aws_iam_role" "lambda" {
-  count              = var.lambda_iam_role_arn == "" ? 1 : 0
-  name_prefix        = var.iam_name_prefix
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
+  count       = var.lambda_iam_role_arn == "" ? 1 : 0
+  name_prefix = var.iam_name_prefix
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Effect    = "Allow"
+      Sid       = ""
+    }]
+  })
 }
 
 resource "aws_cloudwatch_log_group" "group" {
@@ -114,24 +108,14 @@ resource "aws_iam_policy" "lambda_logging" {
   name_prefix = var.iam_name_prefix
   description = "IAM policy for logging from a lambda"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:PutLogEvents"
-      ],
-      "Resource": [
-          "${aws_cloudwatch_log_group.group.arn}*"
-      ]
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+      Resource = ["${aws_cloudwatch_log_group.group.arn}*"]
+    }]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_logs" {
@@ -144,27 +128,19 @@ resource "aws_iam_policy" "vpc_access" {
   name_prefix = var.iam_name_prefix
   description = "IAM policy for attaching to VPC"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:CreateNetworkInterface",
-        "ec2:DescribeNetworkInterfaces",
-        "ec2:DeleteNetworkInterface"
-      ],
-      "Resource": "*",
-      "Condition": {
-        "ArnLikeIfExists": {
-          "ec2:Subnet": ${jsonencode([for s in var.vpc_config.subnets : s.arn])}
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["ec2:CreateNetworkInterface", "ec2:DescribeNetworkInterfaces", "ec2:DeleteNetworkInterface"]
+      Resource = "*"
+      Condition = {
+        ArnLikeIfExists = {
+          "ec2:Subnet" = [for s in var.vpc_config.subnets : s.arn]
         }
       }
-    }
-  ]
-}
-EOF
+    }]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "vpc_access" {
@@ -178,27 +154,19 @@ resource "aws_iam_policy" "kms_decrypt" {
   name_prefix = var.iam_name_prefix
   description = "IAM policy for decrypting ciphertext using KMS"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "kms:Decrypt"
-      ],
-      "Resource": [
-          "${var.kms_key.arn}"
-      ],
-      "Condition": {
-        "StringEquals": {
-          "kms:EncryptionContext:LambdaFunctionName": "${var.name}"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["kms:Decrypt"]
+      Resource = [var.kms_key.arn]
+      Condition = {
+        StringEquals = {
+          "kms:EncryptionContext:LambdaFunctionName" = var.name
         }
       }
-    }
-  ]
-}
-EOF
+    }]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "kms_decrypt" {

--- a/modules/cloudwatch_logs_subscription/README.md
+++ b/modules/cloudwatch_logs_subscription/README.md
@@ -39,14 +39,14 @@ module "observe_lambda_cloudwatch_logs_subscription" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -66,10 +66,10 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account"></a> [account](#input\_account) | Account ID for log groups. If empty, account is assumed to be the same as lambda | `string` | `""` | no |
-| <a name="input_allow_all_log_groups"></a> [allow\_all\_log\_groups](#input\_allow\_all\_log\_groups) | Create a single permission allowing lambda to be triggered by any log group.<br>This works around policy limits when subscribing many log groups to a single lambda." | `bool` | `false` | no |
+| <a name="input_allow_all_log_groups"></a> [allow\_all\_log\_groups](#input\_allow\_all\_log\_groups) | Create a single permission allowing lambda to be triggered by any log group.<br/>This works around policy limits when subscribing many log groups to a single lambda." | `bool` | `false` | no |
 | <a name="input_filter_name"></a> [filter\_name](#input\_filter\_name) | Filter name | `string` | `"observe-filter"` | no |
 | <a name="input_filter_pattern"></a> [filter\_pattern](#input\_filter\_pattern) | The filter pattern to use. For more information, see [Filter and Pattern Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html) | `string` | `""` | no |
-| <a name="input_lambda"></a> [lambda](#input\_lambda) | Observe Lambda module | <pre>object({<br>    arn           = string<br>    function_name = string<br>  })</pre> | n/a | yes |
+| <a name="input_lambda"></a> [lambda](#input\_lambda) | Observe Lambda module | <pre>object({<br/>    arn           = string<br/>    function_name = string<br/>  })</pre> | n/a | yes |
 | <a name="input_log_group_names"></a> [log\_group\_names](#input\_log\_group\_names) | Cloudwatch Log Group names to subscribe to Observe Lambda | `list(string)` | n/a | yes |
 | <a name="input_statement_id_prefix"></a> [statement\_id\_prefix](#input\_statement\_id\_prefix) | Prefix used for Lambda permission statement ID | `string` | `"observe-lambda"` | no |
 

--- a/modules/cloudwatch_logs_subscription/versions.tf
+++ b/modules/cloudwatch_logs_subscription/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.1"
+  required_version = ">= 1.1"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.68"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/cloudwatch_metrics/README.md
+++ b/modules/cloudwatch_metrics/README.md
@@ -39,13 +39,13 @@ module "cloudwatch_metrics" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.68 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 2.68 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -71,10 +71,10 @@ No modules.
 | <a name="input_delay"></a> [delay](#input\_delay) | Collection delay in seconds. This delay accounts for the lag in metrics availability via Cloudwatch API. | `number` | `300` | no |
 | <a name="input_eventbridge_name_prefix"></a> [eventbridge\_name\_prefix](#input\_eventbridge\_name\_prefix) | Prefix used for eventbridge rule | `string` | `"observe-lambda-metrics-"` | no |
 | <a name="input_eventbridge_schedule_event_bus_name"></a> [eventbridge\_schedule\_event\_bus\_name](#input\_eventbridge\_schedule\_event\_bus\_name) | Event Bus for EventBridge scheduled events | `string` | `"default"` | no |
-| <a name="input_filters"></a> [filters](#input\_filters) | List of filters. | <pre>list(object({<br>    namespace    = string<br>    list_mode    = optional(string)<br>    metric_names = optional(list(string))<br>    dimensions = optional(list(object({<br>      name  = string<br>      value = optional(string)<br>    })))<br>  }))</pre> | n/a | yes |
+| <a name="input_filters"></a> [filters](#input\_filters) | List of filters. | <pre>list(object({<br/>    namespace    = string<br/>    list_mode    = optional(string)<br/>    metric_names = optional(list(string))<br/>    dimensions = optional(list(object({<br/>      name  = string<br/>      value = optional(string)<br/>    })))<br/>  }))</pre> | n/a | yes |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `""` | no |
 | <a name="input_interval"></a> [interval](#input\_interval) | Interval in seconds between collection runs. Use a multiple of period to avoid gaps. | `number` | `300` | no |
-| <a name="input_lambda"></a> [lambda](#input\_lambda) | Observe Lambda module | <pre>object({<br>    lambda_function = object({<br>      arn  = string<br>      role = string<br>    })<br>  })</pre> | n/a | yes |
+| <a name="input_lambda"></a> [lambda](#input\_lambda) | Observe Lambda module | <pre>object({<br/>    lambda_function = object({<br/>      arn  = string<br/>      role = string<br/>    })<br/>  })</pre> | n/a | yes |
 | <a name="input_period"></a> [period](#input\_period) | Period in seconds between metric data points. Must be a multiple of 60. | `number` | `60` | no |
 | <a name="input_statement_id_prefix"></a> [statement\_id\_prefix](#input\_statement\_id\_prefix) | Prefix used for Lambda permission statement ID | `string` | `""` | no |
 

--- a/modules/cloudwatch_metrics/versions.tf
+++ b/modules/cloudwatch_metrics/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.68"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/s3_bucket/README.md
+++ b/modules/s3_bucket/README.md
@@ -31,20 +31,20 @@ module "observe_lambda_s3_subscription" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 3.7.0 |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | terraform-aws-modules/s3-bucket/aws | ~> 5.0 |
 
 ## Resources
 

--- a/modules/s3_bucket/main.tf
+++ b/modules/s3_bucket/main.tf
@@ -8,7 +8,7 @@ data "aws_caller_identity" "current" {}
 
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 3.7.0"
+  version = "~> 5.0"
 
   bucket        = var.bucket_name
   acl           = "log-delivery-write"

--- a/modules/s3_bucket/versions.tf
+++ b/modules/s3_bucket/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.1"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.9"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/s3_bucket_subscription/README.md
+++ b/modules/s3_bucket_subscription/README.md
@@ -32,14 +32,14 @@ module "observe_lambda_s3_subscription" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -64,7 +64,7 @@ No modules.
 | <a name="input_filter_prefix"></a> [filter\_prefix](#input\_filter\_prefix) | Specifies object key name prefix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_filter_suffix"></a> [filter\_suffix](#input\_filter\_suffix) | Specifies object key name suffix on S3 bucket notifications. | `string` | `""` | no |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `"observe-lambda-"` | no |
-| <a name="input_lambda"></a> [lambda](#input\_lambda) | Observe Lambda module | <pre>object({<br>    arn  = string<br>    role = string<br>  })</pre> | n/a | yes |
+| <a name="input_lambda"></a> [lambda](#input\_lambda) | Observe Lambda module | <pre>object({<br/>    arn  = string<br/>    role = string<br/>  })</pre> | n/a | yes |
 | <a name="input_statement_id_prefix"></a> [statement\_id\_prefix](#input\_statement\_id\_prefix) | Prefix used for Lambda permission statement ID | `string` | `""` | no |
 
 ## Outputs

--- a/modules/s3_bucket_subscription/main.tf
+++ b/modules/s3_bucket_subscription/main.tf
@@ -36,32 +36,26 @@ resource "aws_iam_policy" "s3_bucket_read" {
   # s3:ListBucket is not strictly required, but it allows us to receive a 404
   # instead of 403 error if an S3 object no longer exists by the time our
   # lambda function tries to retrieve it
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-     "Action": [
-       "s3:ListBucket"
-     ],
-     "Effect": "Allow",
-     "Resource": ${jsonencode(var.bucket_arns)},
-     "Condition":{
-       "StringLike":{
-         "s3:prefix":["${var.filter_prefix}*"]
-       }
-     }
-    },
-    {
-      "Action": [
-        "s3:GetObject"
-      ],
-      "Effect": "Allow",
-      "Resource": ${jsonencode([for i in var.bucket_arns : format("%s/%s*", i, var.filter_prefix)])}
-    }
-  ]
-}
-EOF
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action   = ["s3:ListBucket"]
+        Effect   = "Allow"
+        Resource = var.bucket_arns
+        Condition = {
+          StringLike = {
+            "s3:prefix" = ["${var.filter_prefix}*"]
+          }
+        }
+      },
+      {
+        Action   = ["s3:GetObject"]
+        Effect   = "Allow"
+        Resource = [for i in var.bucket_arns : format("%s/%s*", i, var.filter_prefix)]
+      }
+    ]
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_s3_bucket_read" {

--- a/modules/s3_bucket_subscription/versions.tf
+++ b/modules/s3_bucket_subscription/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.1"
+  required_version = ">= 1.1"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.0"
     }
   }
 }

--- a/modules/snapshot/README.md
+++ b/modules/snapshot/README.md
@@ -93,14 +93,14 @@ module "observe_lambda_snapshot_b" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.73 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.73 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
@@ -123,7 +123,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_action"></a> [action](#input\_action) | List of actions allowed by policy and periodically triggered. By default,<br>this list contains all policies which the lambda can act upon. You should<br>only override this list if you do not want to execute more actions as they<br>become available in future lambda upgrades. If you instead wish to extend<br>this list, or ignore a subset of actions, use \"include\" and \"exclude\". | `list(string)` | <pre>[<br>  "apigateway:Get*",<br>  "apigatewayv2:Get*",<br>  "autoscaling:Describe*",<br>  "cloudformation:Describe*",<br>  "cloudformation:List*",<br>  "cloudfront:List*",<br>  "dynamodb:Describe*",<br>  "dynamodb:List*",<br>  "ec2:Describe*",<br>  "ecs:Describe*",<br>  "ecs:List*",<br>  "eks:Describe*",<br>  "eks:List*",<br>  "elasticbeanstalk:Describe*",<br>  "elasticache:Describe*",<br>  "elasticfilesystem:Describe*",<br>  "elasticloadbalancing:Describe*",<br>  "elasticmapreduce:Describe*",<br>  "elasticmapreduce:List*",<br>  "events:List*",<br>  "firehose:Describe*",<br>  "firehose:List*",<br>  "iam:Get*",<br>  "iam:List*",<br>  "kinesis:Describe*",<br>  "kinesis:List*",<br>  "kms:Describe*",<br>  "kms:List*",<br>  "lambda:List*",<br>  "logs:Describe*",<br>  "organizations:Describe*",<br>  "organizations:List*",<br>  "rds:Describe*",<br>  "redshift:Describe*",<br>  "route53:List*",<br>  "s3:GetBucket*",<br>  "s3:List*",<br>  "secretsmanager:List*",<br>  "sns:Get*",<br>  "sns:List*",<br>  "sqs:Get*",<br>  "sqs:List*",<br>  "synthetics:Describe*",<br>  "synthetics:List*"<br>]</pre> | no |
+| <a name="input_action"></a> [action](#input\_action) | List of actions allowed by policy and periodically triggered. By default,<br/>this list contains all policies which the lambda can act upon. You should<br/>only override this list if you do not want to execute more actions as they<br/>become available in future lambda upgrades. If you instead wish to extend<br/>this list, or ignore a subset of actions, use \"include\" and \"exclude\". | `list(string)` | <pre>[<br/>  "apigateway:Get*",<br/>  "apigatewayv2:Get*",<br/>  "autoscaling:Describe*",<br/>  "cloudformation:Describe*",<br/>  "cloudformation:List*",<br/>  "cloudfront:List*",<br/>  "dynamodb:Describe*",<br/>  "dynamodb:List*",<br/>  "ec2:Describe*",<br/>  "ecs:Describe*",<br/>  "ecs:List*",<br/>  "eks:Describe*",<br/>  "eks:List*",<br/>  "elasticbeanstalk:Describe*",<br/>  "elasticache:Describe*",<br/>  "elasticfilesystem:Describe*",<br/>  "elasticloadbalancing:Describe*",<br/>  "elasticmapreduce:Describe*",<br/>  "elasticmapreduce:List*",<br/>  "events:List*",<br/>  "firehose:Describe*",<br/>  "firehose:List*",<br/>  "iam:Get*",<br/>  "iam:List*",<br/>  "kinesis:Describe*",<br/>  "kinesis:List*",<br/>  "kms:Describe*",<br/>  "kms:List*",<br/>  "lambda:List*",<br/>  "logs:Describe*",<br/>  "organizations:Describe*",<br/>  "organizations:List*",<br/>  "rds:Describe*",<br/>  "redshift:Describe*",<br/>  "route53:List*",<br/>  "s3:GetBucket*",<br/>  "s3:List*",<br/>  "secretsmanager:List*",<br/>  "sns:Get*",<br/>  "sns:List*",<br/>  "sqs:Get*",<br/>  "sqs:List*",<br/>  "synthetics:Describe*",<br/>  "synthetics:List*"<br/>]</pre> | no |
 | <a name="input_eventbridge_name_prefix"></a> [eventbridge\_name\_prefix](#input\_eventbridge\_name\_prefix) | Prefix used for EventBridge Rule | `string` | `"observe-lambda-snapshot-"` | no |
 | <a name="input_eventbridge_schedule_event_bus_name"></a> [eventbridge\_schedule\_event\_bus\_name](#input\_eventbridge\_schedule\_event\_bus\_name) | Event Bus for EventBridge scheduled events | `string` | `"default"` | no |
 | <a name="input_eventbridge_schedule_expression"></a> [eventbridge\_schedule\_expression](#input\_eventbridge\_schedule\_expression) | Rate at which snapshot is triggered. Must be valid EventBridge expression | `string` | `"rate(3 hours)"` | no |
@@ -131,9 +131,9 @@ No modules.
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | Prefix used for all created IAM roles and policies | `string` | `""` | no |
 | <a name="input_include"></a> [include](#input\_include) | List of actions to include in snapshot request. | `list(string)` | `[]` | no |
 | <a name="input_invoke_snapshot_on_start_enabled"></a> [invoke\_snapshot\_on\_start\_enabled](#input\_invoke\_snapshot\_on\_start\_enabled) | Toggle invocation of snapshot from Cloudformation. | `string` | `true` | no |
-| <a name="input_lambda"></a> [lambda](#input\_lambda) | Observe Lambda module | <pre>object({<br>    lambda_function = object({<br>      arn  = string<br>      role = string<br>    })<br>  })</pre> | n/a | yes |
-| <a name="input_overrides"></a> [overrides](#input\_overrides) | List of configuration overrides. | <pre>list(object({<br>    action = string<br>    config = map(any)<br>  }))</pre> | `[]` | no |
-| <a name="input_resources"></a> [resources](#input\_resources) | List of resources to scope policy to. | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_lambda"></a> [lambda](#input\_lambda) | Observe Lambda module | <pre>object({<br/>    lambda_function = object({<br/>      arn  = string<br/>      role = string<br/>    })<br/>  })</pre> | n/a | yes |
+| <a name="input_overrides"></a> [overrides](#input\_overrides) | List of configuration overrides. | <pre>list(object({<br/>    action = string<br/>    config = map(any)<br/>  }))</pre> | `[]` | no |
+| <a name="input_resources"></a> [resources](#input\_resources) | List of resources to scope policy to. | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_statement_id_prefix"></a> [statement\_id\_prefix](#input\_statement\_id\_prefix) | Prefix used for Lambda permission statement ID | `string` | `""` | no |
 
 ## Outputs

--- a/modules/snapshot/versions.tf
+++ b/modules/snapshot/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.1"
+  required_version = ">= 1.1"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 3.73"
+      version = ">= 6.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1.1"
+  required_version = ">= 1.1"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.68"
+      version = ">= 6.0"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replace `data.aws_region.current.id` with `.name` (OBSSD-4274)
- Replace deprecated inline logging/egress blocks in examples with standalone resources
- Bump minimum AWS provider from >= 2.68 to >= 6.0 across all modules
- Upgrade terraform-aws-modules/s3-bucket from ~> 3.7.0 to ~> 4.0
- Convert all IAM policy heredoc (<<EOF) to jsonencode()
- Document all changes and breaking requirements in CHANGELOG

BREAKING CHANGE: Minimum AWS provider version is now >= 6.0. Users on v5.x or below must upgrade before using this module version. s3-bucket module upgraded to ~> 4.0; run `terraform init -upgrade` after updating. 